### PR TITLE
Add connector business logic skeleton

### DIFF
--- a/mobile_client_MAUI_mockup/MainPage.xaml.cs
+++ b/mobile_client_MAUI_mockup/MainPage.xaml.cs
@@ -1,10 +1,15 @@
+using MauiMockup.Services;
+
 ﻿namespace MauiMockup;
 
 public partial class MainPage : ContentPage
 {
+    private readonly Connector _connector = new();
+
     public MainPage()
     {
         InitializeComponent();
+        _connector.StatusUpdate += OnStatusUpdate;
         SetGateName("gate is not configured yet");
         SetGateStatus(EnumGateState.Offline);
     }
@@ -100,7 +105,12 @@ public partial class MainPage : ContentPage
     }
     void OnDoAction(object sender, EventArgs e)
     {
-        // Placeholder for main action
+        _connector.DoAction("default");
+    }
+
+    void OnStatusUpdate(object? sender, string status)
+    {
+        // Placeholder for handling status updates
     }
 
     public enum EnumGateState

--- a/mobile_client_MAUI_mockup/MauiProgram.cs
+++ b/mobile_client_MAUI_mockup/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging;
+using MauiMockup.Services;
 
 namespace MauiMockup
 {
@@ -16,8 +17,9 @@ namespace MauiMockup
                 });
 
 #if DEBUG
-    		builder.Logging.AddDebug();
+            builder.Logging.AddDebug();
 #endif
+            builder.Services.AddSingleton<Connector>();
 
             return builder.Build();
         }

--- a/mobile_client_MAUI_mockup/Services/BluetoothFeed.cs
+++ b/mobile_client_MAUI_mockup/Services/BluetoothFeed.cs
@@ -1,0 +1,13 @@
+namespace MauiMockup.Services;
+
+public class BluetoothFeed : IFeed
+{
+    public event EventHandler<string>? StatusUpdate;
+
+    public Task SendCmd(string command)
+    {
+        // TODO: implement Bluetooth command sending
+        StatusUpdate?.Invoke(this, $"Bluetooth sent: {command}");
+        return Task.CompletedTask;
+    }
+}

--- a/mobile_client_MAUI_mockup/Services/Connector.cs
+++ b/mobile_client_MAUI_mockup/Services/Connector.cs
@@ -1,0 +1,28 @@
+namespace MauiMockup.Services;
+
+public class Connector
+{
+    private readonly IFeed _bluetooth;
+    private readonly IFeed _mqtt;
+
+    public event EventHandler<string>? StatusUpdate;
+
+    public Connector()
+    {
+        _bluetooth = new BluetoothFeed();
+        _bluetooth.StatusUpdate += OnStatusUpdate;
+        _mqtt = new MqttFeed();
+        _mqtt.StatusUpdate += OnStatusUpdate;
+    }
+
+    public Task DoAction(string command)
+    {
+        // TODO: route command to appropriate feed
+        return _bluetooth.SendCmd(command);
+    }
+
+    private void OnStatusUpdate(object? sender, string status)
+    {
+        StatusUpdate?.Invoke(sender, status);
+    }
+}

--- a/mobile_client_MAUI_mockup/Services/IFeed.cs
+++ b/mobile_client_MAUI_mockup/Services/IFeed.cs
@@ -1,0 +1,8 @@
+namespace MauiMockup.Services;
+
+public interface IFeed
+{
+    event EventHandler<string>? StatusUpdate;
+
+    Task SendCmd(string command);
+}

--- a/mobile_client_MAUI_mockup/Services/MqttFeed.cs
+++ b/mobile_client_MAUI_mockup/Services/MqttFeed.cs
@@ -1,0 +1,13 @@
+namespace MauiMockup.Services;
+
+public class MqttFeed : IFeed
+{
+    public event EventHandler<string>? StatusUpdate;
+
+    public Task SendCmd(string command)
+    {
+        // TODO: implement MQTT command sending
+        StatusUpdate?.Invoke(this, $"MQTT sent: {command}");
+        return Task.CompletedTask;
+    }
+}


### PR DESCRIPTION
## Summary
- add IFeed interface and Bluetooth/MQTT feed stubs
- implement Connector coordinating feeds and exposing DoAction
- integrate Connector into MainPage and register with DI

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository signatures 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6bb9dc30832e90c6fbff48ba1017