### PR TITLE
Add status line for Maui mockup action button

### DIFF
--- a/mobile_client_MAUI_mockup/MainPage.xaml
+++ b/mobile_client_MAUI_mockup/MainPage.xaml
@@ -48,7 +48,7 @@
         <Grid x:Name="ContentGrid"
               Grid.Row="2"
               Grid.Column="1"
-              RowDefinitions="Auto,*"
+              RowDefinitions="Auto,*,Auto"
               RowSpacing="40">
 
             <!-- Status list -->
@@ -142,6 +142,14 @@
                     HorizontalOptions="Center"
                     Style="{StaticResource ActionButtonStyle}"
                     Clicked="OnDoAction" />
+
+            <!-- Status text line under the action button -->
+            <Label x:Name="StatusTextLabel"
+                   Grid.Row="2"
+                   Text=""
+                   TextColor="LightGray"
+                   HorizontalOptions="Fill"
+                   HorizontalTextAlignment="Center" />
         </Grid>
     </Grid>
 </ContentPage>

--- a/mobile_client_MAUI_mockup/MainPage.xaml.cs
+++ b/mobile_client_MAUI_mockup/MainPage.xaml.cs
@@ -27,6 +27,8 @@ public partial class MainPage : ContentPage
 
         if (isLandscape)
         {
+            ContentGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+            ContentGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
             ContentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Auto });
             ContentGrid.ColumnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star });
             ContentGrid.RowSpacing = 0;
@@ -36,11 +38,15 @@ public partial class MainPage : ContentPage
             Grid.SetColumn(StatusLayout, 0);
             Grid.SetRow(ActionButton, 0);
             Grid.SetColumn(ActionButton, 1);
+            Grid.SetRow(StatusTextLabel, 1);
+            Grid.SetColumn(StatusTextLabel, 0);
+            Grid.SetColumnSpan(StatusTextLabel, 2);
         }
         else
         {
             ContentGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
             ContentGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+            ContentGrid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
             ContentGrid.RowSpacing = 40;
             ContentGrid.ColumnSpacing = 0;
 
@@ -48,6 +54,8 @@ public partial class MainPage : ContentPage
             Grid.SetColumn(StatusLayout, 0);
             Grid.SetRow(ActionButton, 1);
             Grid.SetColumn(ActionButton, 0);
+            Grid.SetRow(StatusTextLabel, 2);
+            Grid.SetColumn(StatusTextLabel, 0);
         }
     }
 
@@ -151,5 +159,10 @@ public partial class MainPage : ContentPage
         GateStatusLabel.Text = text;
 
         ActionButton.IsEnabled = enable_button;
+    }
+
+    public void SetStatusText(string text)
+    {
+        StatusTextLabel.Text = text;
     }
 }


### PR DESCRIPTION
## Summary
- Add full-width light gray status label beneath the action button in MainPage
- Update layout logic for portrait and landscape orientations to position new status label
- Provide `SetStatusText` method to update the label's content

## Testing
- `dotnet build MauiMockup.sln` *(fails: command not found)*
- `apt-get update` *(fails: repository access denied 403)*

------
https://chatgpt.com/codex/tasks/task_e_68bd77e1eda4832e9942973717240b9b