### PR TITLE
Add fading behaviour to status text

### DIFF
--- a/mobile_client_MAUI_mockup/Components/StatusTextManager.cs
+++ b/mobile_client_MAUI_mockup/Components/StatusTextManager.cs
@@ -1,0 +1,65 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Maui.Controls;
+
+namespace MauiMockup.Components;
+
+/// <summary>
+/// Provides logic for displaying status text with a timed fade-out.
+/// </summary>
+public class StatusTextManager
+{
+    private readonly Label _label;
+    private CancellationTokenSource? _cancellation;
+
+    private static readonly TimeSpan VisibleDuration = TimeSpan.FromSeconds(2);
+    private const uint FadeDuration = 500;
+
+    public StatusTextManager(Label label)
+    {
+        _label = label;
+    }
+
+    /// <summary>
+    /// Sets the status text and schedules it to fade away.
+    /// </summary>
+    public void SetText(string text)
+    {
+        _cancellation?.Cancel();
+        _cancellation?.Dispose();
+        _cancellation = null;
+        _label.CancelAnimations();
+
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            _label.Text = string.Empty;
+            _label.Opacity = 0;
+            return;
+        }
+
+        _label.Text = text;
+        _label.Opacity = 1;
+
+        _cancellation = new CancellationTokenSource();
+        _ = FadeOutAsync(_cancellation.Token);
+    }
+
+    private async Task FadeOutAsync(CancellationToken token)
+    {
+        try
+        {
+            await Task.Delay(VisibleDuration, token);
+            await _label.FadeTo(0, FadeDuration, Easing.Linear);
+            if (!token.IsCancellationRequested)
+            {
+                _label.Text = string.Empty;
+            }
+        }
+        catch (TaskCanceledException)
+        {
+            // ignored
+        }
+    }
+}
+

--- a/mobile_client_MAUI_mockup/MainPage.xaml.cs
+++ b/mobile_client_MAUI_mockup/MainPage.xaml.cs
@@ -1,18 +1,21 @@
 using MauiMockup.Services;
+using MauiMockup.Components;
 
-﻿namespace MauiMockup;
+namespace MauiMockup;
 
 public partial class MainPage : ContentPage
 {
     private readonly Connector _connector = new();
+    private readonly StatusTextManager _statusTextManager;
 
     public MainPage()
     {
         InitializeComponent();
+        _statusTextManager = new StatusTextManager(StatusTextLabel);
         _connector.StatusUpdate += OnStatusUpdate;
         SetGateName("gate is not configured yet");
         SetGateStatus(EnumGateState.Offline);
-        SetStatusText("");
+        SetStatusText(string.Empty);
     }
     protected override void OnSizeAllocated(double width, double height)
     {
@@ -167,6 +170,6 @@ public partial class MainPage : ContentPage
     }
     public void SetStatusText(string text)
     {
-        StatusTextLabel.Text = text;
+        _statusTextManager.SetText(text);
     }
 }


### PR DESCRIPTION
## Summary
- Extract status text fading into dedicated component
- Update MainPage to use component and reset countdown on each update

## Testing
- `dotnet build mobile_client_MAUI_mockup/MauiMockup.csproj` *(fails: command not found: dotnet)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_68bd81f14a40832e9aacd6c57d010b57