### PR TITLE
Make ProtocolTest connector singleton

### DIFF
--- a/simulation/ProtocolTest/Service/Connector/Connector.cs
+++ b/simulation/ProtocolTest/Service/Connector/Connector.cs
@@ -1,17 +1,15 @@
-﻿using System;
+using System;
 
 namespace ProtocolTest.Service.Connector
 {
     internal class Connector
     {
-        public Connector()
-        {
-        }
-        public static bool SendCommand(string command)
+        public bool SendCommand(string command)
         {
             return true;
         }
-        public static bool SetCallback(Action<string> callback)
+
+        public bool SetCallback(Action<string> callback)
         {
             return true;
         }

--- a/simulation/ProtocolTest/Service/ConnectorWraper.cs
+++ b/simulation/ProtocolTest/Service/ConnectorWraper.cs
@@ -1,11 +1,19 @@
-﻿namespace ProtocolTest.Service
+using System;
+using ProtocolTest.Service.Connector;
+
+namespace ProtocolTest.Service
 {
     internal class ConnectorWraper
     {
-        public ConnectorWraper(IConnector connector)
+        private static Connector? _connector;
+
+        public ConnectorWraper()
         {
-            Connector = connector;
+            _connector ??= new Connector();
         }
-        public IConnector Connector { get; }
+
+        public bool SendCommand(string command) => _connector!.SendCommand(command);
+
+        public bool SetCallback(Action<string> callback) => _connector!.SetCallback(callback);
     }
 }


### PR DESCRIPTION
## Summary
- remove `IConnector` interface
- ensure `ConnectorWraper` shares a single `Connector` instance across all wrappers

## Testing
- `dotnet build` *(fails: command not found)*
- `sudo apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c081943840832eace08a4480367e2d