### PR TITLE
Add host unit tests for esp32_mcu project

### DIFF
--- a/esp32_mcu/CMakeLists.txt
+++ b/esp32_mcu/CMakeLists.txt
@@ -14,3 +14,11 @@ set(EXTRA_COMPONENT_DIRS components)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fno-exceptions -fno-rtti" CACHE STRING "" FORCE)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O2")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O2")
+
+add_custom_target(run_unit_tests ALL
+    COMMAND ${CMAKE_COMMAND} -S ${CMAKE_SOURCE_DIR}/tests -B ${CMAKE_BINARY_DIR}/tests
+    COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/tests
+    COMMAND ${CMAKE_CTEST_COMMAND} --test-dir ${CMAKE_BINARY_DIR}/tests --output-on-failure
+    DEPENDS app
+    COMMENT "Building and running native unit tests"
+)

--- a/esp32_mcu/tests/CMakeLists.txt
+++ b/esp32_mcu/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.16)
+project(native_unit_tests C)
+
+enable_testing()
+
+file(GLOB TEST_SOURCES "test_*.c")
+
+get_filename_component(PROJECT_ROOT "${CMAKE_CURRENT_LIST_DIR}/.." ABSOLUTE)
+
+foreach(test_src ${TEST_SOURCES})
+    get_filename_component(test_name ${test_src} NAME_WE)
+    add_executable(${test_name} ${test_src})
+    target_include_directories(${test_name} PRIVATE 
+        ${PROJECT_ROOT}/components
+        ${PROJECT_ROOT}/components/clients 
+        ${PROJECT_ROOT}/components/common 
+        ${CMAKE_CURRENT_LIST_DIR})
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()

--- a/esp32_mcu/tests/test_clients.c
+++ b/esp32_mcu/tests/test_clients.c
@@ -1,0 +1,18 @@
+#include "unity.h"
+#include "clients/clients.h"
+#include <string.h>
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_clients_namespace_length(void)
+{
+    TEST_ASSERT_LESS_OR_EQUAL_UINT32(15, strlen(CLIENTS_DB_NAMESPACE));
+}
+
+int main(void)
+{
+    UNITY_BEGIN();
+    RUN_TEST(test_clients_namespace_length);
+    return UNITY_END();
+}

--- a/esp32_mcu/tests/unity.h
+++ b/esp32_mcu/tests/unity.h
@@ -1,0 +1,37 @@
+#ifndef SIMPLE_UNITY_H
+#define SIMPLE_UNITY_H
+
+#include <stdio.h>
+#include <stdint.h>
+
+static unsigned int UnityTestsPassed = 0;
+static unsigned int UnityTestsFailed = 0;
+
+static inline void UnityBegin(void) {
+    UnityTestsPassed = 0;
+    UnityTestsFailed = 0;
+}
+
+static inline int UnityEnd(void) {
+    printf("%u Tests %u Failures\n", UnityTestsPassed + UnityTestsFailed, UnityTestsFailed);
+    return UnityTestsFailed;
+}
+
+#define UNITY_BEGIN() (UnityBegin(), 0)
+#define UNITY_END() UnityEnd()
+
+#define RUN_TEST(func) do { \
+    printf("RUNNING %s\n", #func); \
+    func(); \
+} while (0)
+
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT32(expected, actual) do { \
+    if ((uint32_t)(actual) <= (uint32_t)(expected)) { \
+        UnityTestsPassed++; \
+    } else { \
+        UnityTestsFailed++; \
+        printf("Assertion failed: expected <= %u but was %u\n", (unsigned)(expected), (unsigned)(actual)); \
+    } \
+} while (0)
+
+#endif // SIMPLE_UNITY_H


### PR DESCRIPTION
## Summary
- run native unit tests automatically after each build via `run_unit_tests` target
- scan `tests/` for `test_*.c` and build/run them on the host
- add initial test validating `CLIENTS_DB_NAMESPACE` length

## Testing
- `cmake -S tests -B build_tests && cmake --build build_tests && ctest --test-dir build_tests --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_68c6eca647b8832e96f338ab1137054b