### PR TITLE
Add host test harness with Unity and ESP-IDF mocks

### DIFF
--- a/esp32_mcu/CMakeLists.txt
+++ b/esp32_mcu/CMakeLists.txt
@@ -32,7 +32,19 @@ if(TAPGATE_BUILD_MODE_LOWER STREQUAL "host")
         return()
     endif()
 
+    if(NOT DEFINED CTEST_CONFIGURATION_TYPE)
+        set(CTEST_CONFIGURATION_TYPE "Debug" CACHE STRING
+            "Default configuration for CTest when using multi-config generators")
+    endif()
+
     enable_testing()
+
+    if(CMAKE_CONFIGURATION_TYPES)
+        file(CONFIGURE OUTPUT "${CMAKE_BINARY_DIR}/CTestCustom.cmake" CONTENT
+"# Auto-generated to help IDE test runners pick the default multi-config profile.\nset(CTEST_CONFIGURATION_TYPE \"${CTEST_CONFIGURATION_TYPE}\")\nset(ENV{CTEST_CONFIGURATION_TYPE} \"${CTEST_CONFIGURATION_TYPE}\")\n"
+        @ONLY)
+    endif()
+
     add_subdirectory(tests_host)
     return()
 elseif(NOT TAPGATE_BUILD_MODE_LOWER STREQUAL "idf")

--- a/esp32_mcu/CMakeLists.txt
+++ b/esp32_mcu/CMakeLists.txt
@@ -1,10 +1,51 @@
-# The following five lines of boilerplate have to be in your project's
-# CMakeLists in this exact order for cmake to work correctly
-cmake_minimum_required(VERSION 3.5)
+# Unified entry point for both ESP-IDF firmware build and host-side tests.
+cmake_minimum_required(VERSION 3.20)
 
 set(PROJECT_NAME esp32-tapgate)
 set(PROJECT_VER "1.0.0")
 
+# Determine which build flow should be enabled. When using Visual Studio
+# generator we default to the host-only test configuration so that the IDE can
+# discover the unit tests without the ESP-IDF toolchain. The mode can be
+# overridden explicitly with -DTAPGATE_BUILD_MODE={idf,host}.
+if(NOT DEFINED TAPGATE_BUILD_MODE)
+    if(CMAKE_GENERATOR MATCHES "Visual Studio")
+        set(TAPGATE_BUILD_MODE "host")
+    else()
+        set(TAPGATE_BUILD_MODE "idf")
+    endif()
+endif()
+
+string(TOLOWER "${TAPGATE_BUILD_MODE}" TAPGATE_BUILD_MODE_LOWER)
+
+if(TAPGATE_BUILD_MODE_LOWER STREQUAL "host")
+    project(${PROJECT_NAME}_host_tests LANGUAGES C)
+
+    set(CMAKE_C_STANDARD 11)
+    set(CMAKE_C_STANDARD_REQUIRED ON)
+    set(CMAKE_C_EXTENSIONS OFF)
+
+    include(CTest)
+    if(NOT BUILD_TESTING)
+        message(STATUS "Host unit tests are disabled (BUILD_TESTING=OFF)")
+    else()
+        enable_testing()
+        add_subdirectory(tests_host)
+    endif()
+
+    return()
+elseif(NOT TAPGATE_BUILD_MODE_LOWER STREQUAL "idf")
+    message(FATAL_ERROR "Unknown TAPGATE_BUILD_MODE value: ${TAPGATE_BUILD_MODE}."
+                           " Expected 'idf' or 'host'.")
+endif()
+
+if(NOT DEFINED ENV{IDF_PATH} OR NOT EXISTS "$ENV{IDF_PATH}/tools/cmake/project.cmake")
+    message(FATAL_ERROR
+        "ESP-IDF environment is not available. Set TAPGATE_BUILD_MODE=host to "
+        "configure only the host unit tests.")
+endif()
+
+# The following boilerplate must remain in this order for ESP-IDF projects.
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 project(${PROJECT_NAME})
 

--- a/esp32_mcu/CMakeLists.txt
+++ b/esp32_mcu/CMakeLists.txt
@@ -4,16 +4,17 @@ cmake_minimum_required(VERSION 3.20)
 set(PROJECT_NAME esp32-tapgate)
 set(PROJECT_VER "1.0.0")
 
-# Determine which build flow should be enabled. When using Visual Studio
-# generator we default to the host-only test configuration so that the IDE can
-# discover the unit tests without the ESP-IDF toolchain. The mode can be
-# overridden explicitly with -DTAPGATE_BUILD_MODE={idf,host}.
+# Detect which toolchain is driving CMake. ESP-IDF passes ESP_PLATFORM whereas
+# a native host configuration (e.g. Visual Studio, Ninja with the local
+# compiler) leaves it unset. Allow manual override through
+# -DTAPGATE_BUILD_MODE={idf,host} so developers can choose explicitly.
+set(_tapgate_default_mode "host")
+if(DEFINED ESP_PLATFORM AND ESP_PLATFORM)
+    set(_tapgate_default_mode "idf")
+endif()
+
 if(NOT DEFINED TAPGATE_BUILD_MODE)
-    if(CMAKE_GENERATOR MATCHES "Visual Studio")
-        set(TAPGATE_BUILD_MODE "host")
-    else()
-        set(TAPGATE_BUILD_MODE "idf")
-    endif()
+    set(TAPGATE_BUILD_MODE "${_tapgate_default_mode}")
 endif()
 
 string(TOLOWER "${TAPGATE_BUILD_MODE}" TAPGATE_BUILD_MODE_LOWER)
@@ -28,15 +29,15 @@ if(TAPGATE_BUILD_MODE_LOWER STREQUAL "host")
     include(CTest)
     if(NOT BUILD_TESTING)
         message(STATUS "Host unit tests are disabled (BUILD_TESTING=OFF)")
-    else()
-        enable_testing()
-        add_subdirectory(tests_host)
+        return()
     endif()
 
+    enable_testing()
+    add_subdirectory(tests_host)
     return()
 elseif(NOT TAPGATE_BUILD_MODE_LOWER STREQUAL "idf")
     message(FATAL_ERROR "Unknown TAPGATE_BUILD_MODE value: ${TAPGATE_BUILD_MODE}."
-                           " Expected 'idf' or 'host'.")
+                         " Expected 'idf' or 'host'.")
 endif()
 
 if(NOT DEFINED ENV{IDF_PATH} OR NOT EXISTS "$ENV{IDF_PATH}/tools/cmake/project.cmake")

--- a/esp32_mcu/CMakePresets.json
+++ b/esp32_mcu/CMakePresets.json
@@ -1,0 +1,27 @@
+{
+    "version": 5,
+    "configurePresets": [
+        {
+            "name": "host-tests",
+            "displayName": "Host tests (native)",
+            "description": "Configure the host-only unit tests using the native toolchain.",
+            "binaryDir": "${sourceDir}/build-host-tests",
+            "cacheVariables": {
+                "TAPGATE_BUILD_MODE": "host",
+                "BUILD_TESTING": "ON"
+            }
+        }
+    ],
+    "buildPresets": [
+        {
+            "name": "host-tests",
+            "configurePreset": "host-tests"
+        }
+    ],
+    "testPresets": [
+        {
+            "name": "host-tests",
+            "configurePreset": "host-tests"
+        }
+    ]
+}

--- a/esp32_mcu/CMakePresets.json
+++ b/esp32_mcu/CMakePresets.json
@@ -15,13 +15,18 @@
     "buildPresets": [
         {
             "name": "host-tests",
-            "configurePreset": "host-tests"
+            "configurePreset": "host-tests",
+            "configuration": "Debug"
         }
     ],
     "testPresets": [
         {
             "name": "host-tests",
-            "configurePreset": "host-tests"
+            "configurePreset": "host-tests",
+            "configuration": "Debug",
+            "environment": {
+                "CTEST_CONFIGURATION_TYPE": "Debug"
+            }
         }
     ]
 }

--- a/esp32_mcu/README.md
+++ b/esp32_mcu/README.md
@@ -11,13 +11,17 @@ High-level view of the software design, components, and how modules interact.
 Modules:
 - [Clients](../docs/device/module-clients.md) — Clients module details.
 
-## Setup & Configuration  
-Instructions for preparing the environment, building, flashing, and monitoring.  
-- [How-To Build Guide](../docs/device/howto.md) — step-by-step guide on how to set up and compile the project.  
+## Setup & Configuration
+Instructions for preparing the environment, building, flashing, and monitoring.
+- [How-To Build Guide](../docs/device/howto.md) — step-by-step guide on how to set up and compile the project.
 
-## Protocol  
-Description of the communication protocol between ESP32 and external clients.  
-- [Communication Protocol](../docs/general/protocol.md) — message format, sequences, and error handling.  
+### Host unit tests
+- Configure the native test project with `cmake --preset host-tests` to work with IDE test runners. The preset builds the sources under `tests_host` without requiring the ESP-IDF toolchain.
+- Build and execute the suite locally via `cmake --build --preset host-tests` followed by `ctest --preset host-tests`.
+
+## Protocol
+Description of the communication protocol between ESP32 and external clients.
+- [Communication Protocol](../docs/general/protocol.md) — message format, sequences, and error handling.
 
 ---
 

--- a/esp32_mcu/README.md
+++ b/esp32_mcu/README.md
@@ -16,9 +16,10 @@ Instructions for preparing the environment, building, flashing, and monitoring.
 - [How-To Build Guide](../docs/device/howto.md) — step-by-step guide on how to set up and compile the project.
 
 ### Host unit tests
-- Configure the native test project with `cmake --preset host-tests` to work with IDE test runners. The preset builds the sources under `tests_host` without requiring the ESP-IDF toolchain.
-- Build and execute the suite locally via `cmake --build --preset host-tests` followed by `ctest --preset host-tests`.
-- If CMake is invoked without ESP-IDF's `ESP_PLATFORM` flag (for example when selecting a Visual Studio kit), the top-level project automatically enters the host-test configuration so IDE test menus can discover the executables.
+- Configure the native test project with `cmake --preset host-tests` so IDEs can pick up the generated `CTest` metadata. The preset enables `BUILD_TESTING` and never requires the ESP-IDF toolchain.
+- Build and execute the suite locally via `cmake --build --preset host-tests` followed by `ctest --preset host-tests` (the preset already passes the correct `-C Debug` flag for multi-config generators).
+- Each Unity binary understands `--list` to enumerate available test names and `--filter <substring>` to run a subset, which helps when dispatching single cases from IDE menus.
+- When CMake is invoked without ESP-IDF's `ESP_PLATFORM` flag (for example when selecting a Visual Studio kit), the top-level project automatically enters the host-test configuration so IDE test menus can discover the executables.
 
 ## Protocol
 Description of the communication protocol between ESP32 and external clients.

--- a/esp32_mcu/README.md
+++ b/esp32_mcu/README.md
@@ -18,6 +18,7 @@ Instructions for preparing the environment, building, flashing, and monitoring.
 ### Host unit tests
 - Configure the native test project with `cmake --preset host-tests` to work with IDE test runners. The preset builds the sources under `tests_host` without requiring the ESP-IDF toolchain.
 - Build and execute the suite locally via `cmake --build --preset host-tests` followed by `ctest --preset host-tests`.
+- If CMake is invoked without ESP-IDF's `ESP_PLATFORM` flag (for example when selecting a Visual Studio kit), the top-level project automatically enters the host-test configuration so IDE test menus can discover the executables.
 
 ## Protocol
 Description of the communication protocol between ESP32 and external clients.

--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -1,2 +1,65 @@
 # Minimal, self-contained host test project (no IDF toolchain).
 cmake_minimum_required(VERSION 3.20)
+project(esp32_tapgate_host_tests C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+include(CTest)
+if(NOT BUILD_TESTING)
+    message(STATUS "Host unit tests are disabled (BUILD_TESTING=OFF)")
+    return()
+endif()
+
+enable_testing()
+
+# Unity test framework (minimal implementation for host tests)
+add_library(unity STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/unity/unity.c
+)
+
+target_include_directories(unity
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/unity
+)
+
+# Interface library that exposes production headers and IDF mocks to the tests.
+add_library(tapgate_headers INTERFACE)
+
+target_include_directories(tapgate_headers
+    INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/../components
+        ${CMAKE_CURRENT_LIST_DIR}/../components/clients
+        ${CMAKE_CURRENT_LIST_DIR}/../components/common
+        ${CMAKE_CURRENT_LIST_DIR}/mocks/include
+)
+
+# Static library with the production sources that are safe to build on the host.
+add_library(tapgate_components STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/../components/clients/clients.c
+)
+
+# Link headers (with mocks) to the production library for tests.
+target_link_libraries(tapgate_components
+    PUBLIC
+        tapgate_headers
+)
+
+# Helper function to register Unity-based executables as CTest targets.
+function(add_unity_test TEST_NAME)
+    if(NOT ARGN)
+        message(FATAL_ERROR "No source file provided for test ${TEST_NAME}")
+    endif()
+    add_executable(${TEST_NAME} ${ARGN})
+    target_link_libraries(${TEST_NAME}
+        PRIVATE
+            unity
+            tapgate_components
+    )
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+endfunction()
+
+# Individual test binaries
+add_unity_test(test_clients ${CMAKE_CURRENT_LIST_DIR}/test_clients.c)
+add_unity_test(test_types ${CMAKE_CURRENT_LIST_DIR}/test_types.c)

--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -4,7 +4,7 @@
 # as a subdirectory.
 if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
     cmake_minimum_required(VERSION 3.20)
-    project(esp32_tapgate_host_tests C)
+    project(esp32_tapgate_host_tests LANGUAGES C)
 endif()
 
 set(CMAKE_C_STANDARD 11)
@@ -29,42 +29,97 @@ target_include_directories(unity
         ${CMAKE_CURRENT_LIST_DIR}/unity
 )
 
-# Interface library that exposes production headers and IDF mocks to the tests.
-add_library(tapgate_headers INTERFACE)
+# Interface library exposing ESP-IDF shims used when compiling production
+# sources on the host.
+add_library(tapgate_idf_mocks INTERFACE)
 
-target_include_directories(tapgate_headers
+target_include_directories(tapgate_idf_mocks
     INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/../components
-        ${CMAKE_CURRENT_LIST_DIR}/../components/clients
-        ${CMAKE_CURRENT_LIST_DIR}/../components/common
         ${CMAKE_CURRENT_LIST_DIR}/mocks/include
 )
 
-# Static library with the production sources that are safe to build on the host.
-add_library(tapgate_components STATIC
+# Static library with production sources that are safe to build on the host.
+add_library(tapgate_production STATIC)
+
+target_link_libraries(tapgate_production
+    PUBLIC
+        tapgate_idf_mocks
+)
+
+target_compile_features(tapgate_production
+    PUBLIC
+        c_std_11
+)
+
+target_include_directories(tapgate_production
+    PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/../components
+        ${CMAKE_CURRENT_LIST_DIR}/../components/clients
+        ${CMAKE_CURRENT_LIST_DIR}/../components/common
+)
+
+set(_tapgate_component_sources
     ${CMAKE_CURRENT_LIST_DIR}/../components/clients/clients.c
 )
 
-# Link headers (with mocks) to the production library for tests.
-target_link_libraries(tapgate_components
-    PUBLIC
-        tapgate_headers
+file(GLOB _tapgate_common_sources
+    "${CMAKE_CURRENT_LIST_DIR}/../components/common/*.c"
 )
 
+list(APPEND _tapgate_component_sources ${_tapgate_common_sources})
+
+# Drop empty strings and zero-length sources to avoid compiler warnings from
+# placeholder files that ship with the firmware tree.
+set(_tapgate_filtered_sources)
+foreach(_tapgate_source IN LISTS _tapgate_component_sources)
+    if(NOT _tapgate_source)
+        continue()
+    endif()
+    if(NOT EXISTS "${_tapgate_source}")
+        continue()
+    endif()
+    file(SIZE "${_tapgate_source}" _tapgate_source_size)
+    if(_tapgate_source_size EQUAL 0)
+        continue()
+    endif()
+    list(APPEND _tapgate_filtered_sources "${_tapgate_source}")
+endforeach()
+
+set(_tapgate_component_sources ${_tapgate_filtered_sources})
+
+if(_tapgate_component_sources)
+    target_sources(tapgate_production
+        PRIVATE
+            ${_tapgate_component_sources}
+    )
+endif()
+
+if(MSVC)
+    target_compile_options(tapgate_production PRIVATE /W4)
+else()
+    target_compile_options(tapgate_production PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
 # Helper function to register Unity-based executables as CTest targets.
-function(add_unity_test TEST_NAME)
+function(tapgate_add_unity_test TEST_NAME)
     if(NOT ARGN)
         message(FATAL_ERROR "No source file provided for test ${TEST_NAME}")
     endif()
+
     add_executable(${TEST_NAME} ${ARGN})
     target_link_libraries(${TEST_NAME}
         PRIVATE
             unity
-            tapgate_components
+            tapgate_production
     )
+    if(MSVC)
+        target_compile_options(${TEST_NAME} PRIVATE /W4)
+    else()
+        target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -Wpedantic)
+    endif()
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
 endfunction()
 
 # Individual test binaries
-add_unity_test(test_clients ${CMAKE_CURRENT_LIST_DIR}/test_clients.c)
-add_unity_test(test_types ${CMAKE_CURRENT_LIST_DIR}/test_types.c)
+tapgate_add_unity_test(test_clients ${CMAKE_CURRENT_LIST_DIR}/test_clients.c)
+tapgate_add_unity_test(test_types ${CMAKE_CURRENT_LIST_DIR}/test_types.c)

--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -1,6 +1,11 @@
-# Minimal, self-contained host test project (no IDF toolchain).
-cmake_minimum_required(VERSION 3.20)
-project(esp32_tapgate_host_tests C)
+# Minimal, self-contained host test project (no IDF toolchain). When included
+# from the top-level CMake project the configuration already defines the
+# project(), so the logic below needs to behave both as a standalone project and
+# as a subdirectory.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    cmake_minimum_required(VERSION 3.20)
+    project(esp32_tapgate_host_tests C)
+endif()
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)

--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -117,7 +117,25 @@ function(tapgate_add_unity_test TEST_NAME)
     else()
         target_compile_options(${TEST_NAME} PRIVATE -Wall -Wextra -Wpedantic)
     endif()
-    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+    list(GET ARGN 0 _tapgate_first_source)
+    if(_tapgate_first_source)
+        get_filename_component(_tapgate_first_source "${_tapgate_first_source}" ABSOLUTE)
+    else()
+        set(_tapgate_first_source "${CMAKE_CURRENT_SOURCE_DIR}")
+    endif()
+    file(RELATIVE_PATH _tapgate_source_label "${CMAKE_SOURCE_DIR}" "${_tapgate_first_source}")
+
+    set_target_properties(${TEST_NAME}
+        PROPERTIES
+            VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:${TEST_NAME}>"
+    )
+
+    add_test(NAME ${TEST_NAME} COMMAND $<TARGET_FILE:${TEST_NAME}>)
+    set_tests_properties(${TEST_NAME}
+        PROPERTIES
+            WORKING_DIRECTORY "$<TARGET_FILE_DIR:${TEST_NAME}>"
+            LABELS "tests_host;${TEST_NAME};${_tapgate_source_label}"
+    )
 endfunction()
 
 # Individual test binaries

--- a/esp32_mcu/tests_host/mocks/include/esp_err.h
+++ b/esp32_mcu/tests_host/mocks/include/esp_err.h
@@ -1,0 +1,65 @@
+#pragma once
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef int32_t esp_err_t;
+
+#define ESP_OK           0
+#define ESP_FAIL        -1
+#define ESP_ERR_NO_MEM   0x101
+#define ESP_ERR_INVALID_ARG 0x102
+#define ESP_ERR_NOT_FOUND   0x103
+#define ESP_ERR_TIMEOUT     0x104
+
+static inline const char *esp_err_to_name(esp_err_t code)
+{
+    switch (code)
+    {
+        case ESP_OK:
+            return "ESP_OK";
+        case ESP_FAIL:
+            return "ESP_FAIL";
+        case ESP_ERR_NO_MEM:
+            return "ESP_ERR_NO_MEM";
+        case ESP_ERR_INVALID_ARG:
+            return "ESP_ERR_INVALID_ARG";
+        case ESP_ERR_NOT_FOUND:
+            return "ESP_ERR_NOT_FOUND";
+        case ESP_ERR_TIMEOUT:
+            return "ESP_ERR_TIMEOUT";
+        default:
+            return "ESP_ERR_UNKNOWN";
+    }
+}
+
+#define ESP_ERROR_CHECK(x)                                                      \
+    do {                                                                        \
+        esp_err_t __err_rc = (x);                                               \
+        if (__err_rc != ESP_OK)                                                 \
+        {                                                                       \
+            fprintf(stderr, "ESP_ERROR_CHECK failed: %s (%d)\n",              \
+                    esp_err_to_name(__err_rc), (int)__err_rc);                  \
+            abort();                                                            \
+        }                                                                       \
+    } while (0)
+
+#define ESP_ERROR_CHECK_WITHOUT_ABORT(x)                                        \
+    do {                                                                        \
+        esp_err_t __err_rc = (x);                                               \
+        if (__err_rc != ESP_OK)                                                 \
+        {                                                                       \
+            fprintf(stderr, "ESP_ERROR_CHECK_WITHOUT_ABORT failed: %s (%d)\n", \
+                    esp_err_to_name(__err_rc), (int)__err_rc);                  \
+        }                                                                       \
+    } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/esp32_mcu/tests_host/mocks/include/esp_log.h
+++ b/esp32_mcu/tests_host/mocks/include/esp_log.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stdio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    ESP_LOG_NONE,
+    ESP_LOG_ERROR,
+    ESP_LOG_WARN,
+    ESP_LOG_INFO,
+    ESP_LOG_DEBUG,
+    ESP_LOG_VERBOSE
+} esp_log_level_t;
+
+static inline void esp_log_level_set(const char *tag, esp_log_level_t level)
+{
+    (void)tag;
+    (void)level;
+}
+
+#define ESP_LOGE(tag, fmt, ...) fprintf(stderr, "[E] %s: " fmt "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGW(tag, fmt, ...) fprintf(stderr, "[W] %s: " fmt "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGI(tag, fmt, ...) fprintf(stdout, "[I] %s: " fmt "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGD(tag, fmt, ...) fprintf(stdout, "[D] %s: " fmt "\n", tag, ##__VA_ARGS__)
+#define ESP_LOGV(tag, fmt, ...) fprintf(stdout, "[V] %s: " fmt "\n", tag, ##__VA_ARGS__)
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/esp32_mcu/tests_host/mocks/include/sdkconfig.h
+++ b/esp32_mcu/tests_host/mocks/include/sdkconfig.h
@@ -1,0 +1,7 @@
+#pragma once
+
+/*
+ * Dummy sdkconfig header for host-unit tests. Production firmware includes the
+ * generated configuration from ESP-IDF; host tests provide only the options
+ * that are actually required by the compiled sources.
+ */

--- a/esp32_mcu/tests_host/test_clients.c
+++ b/esp32_mcu/tests_host/test_clients.c
@@ -10,8 +10,9 @@ void test_clients_namespace_length(void)
     TEST_ASSERT_LESS_OR_EQUAL_UINT32(15, strlen(CLIENTS_DB_NAMESPACE));
 }
 
-int main(void)
+int main(int argc, char **argv)
 {
+    UnityConfigureFromArgs(argc, (const char **)argv);
     UNITY_BEGIN();
     RUN_TEST(test_clients_namespace_length);
     return UNITY_END();

--- a/esp32_mcu/tests_host/test_types.c
+++ b/esp32_mcu/tests_host/test_types.c
@@ -10,8 +10,9 @@ void test_types_client_id_length(void)
     TEST_ASSERT_LESS_OR_EQUAL_UINT32(15, sizeof(client_uid_t));
 }
 
-int main(void)
+int main(int argc, char **argv)
 {
+    UnityConfigureFromArgs(argc, (const char **)argv);
     UNITY_BEGIN();
     RUN_TEST(test_types_client_id_length);
     return UNITY_END();

--- a/esp32_mcu/tests_host/unity/unity.c
+++ b/esp32_mcu/tests_host/unity/unity.c
@@ -1,0 +1,151 @@
+#include "unity.h"
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+
+UnityContext Unity = {0};
+
+extern void setUp(void);
+extern void tearDown(void);
+
+static void unity_print_test_header(const char *name)
+{
+    if (name)
+    {
+        printf("[ RUN      ] %s\n", name);
+    }
+}
+
+static void unity_print_test_result(const char *name, bool failed)
+{
+    if (!name)
+        return;
+
+    if (failed)
+    {
+        printf("[  FAILED  ] %s\n", name);
+    }
+    else
+    {
+        printf("[       OK ] %s\n", name);
+    }
+}
+
+void UnityBegin(const char *filename)
+{
+    Unity.total_tests = 0U;
+    Unity.failed_tests = 0U;
+    Unity.current_test_name = NULL;
+    Unity.current_test_line = 0U;
+    Unity.current_test_file = filename;
+    Unity.current_test_failed = false;
+
+    printf("==== Unity host test runner (%s) ====\n", filename ? filename : "<unknown>");
+}
+
+int UnityEnd(void)
+{
+    printf("==== Tests: %u, Failures: %u ====\n", Unity.total_tests, Unity.failed_tests);
+    return (int)Unity.failed_tests;
+}
+
+void UnityMessage(const char *message, unsigned int line_number)
+{
+    if (message)
+    {
+        printf("%s:%u: %s\n", Unity.current_test_name ? Unity.current_test_name : "<test>", line_number, message);
+    }
+}
+
+void UnityFail(const char *message, unsigned int line_number)
+{
+    Unity.current_test_failed = true;
+    if (message)
+    {
+        fprintf(stderr, "%s:%u: %s\n", Unity.current_test_name ? Unity.current_test_name : "<test>", line_number, message);
+    }
+    else
+    {
+        fprintf(stderr, "%s:%u: Test failed\n", Unity.current_test_name ? Unity.current_test_name : "<test>", line_number);
+    }
+}
+
+bool UnityAssert(bool condition, const char *message, unsigned int line_number)
+{
+    if (condition)
+        return true;
+
+    UnityFail(message, line_number);
+    return false;
+}
+
+bool UnityAssertEqualInt(long expected, long actual, unsigned int line_number)
+{
+    if (expected == actual)
+        return true;
+
+    char buffer[128];
+    (void)snprintf(buffer, sizeof(buffer), "Expected %ld but was %ld", expected, actual);
+    UnityFail(buffer, line_number);
+    return false;
+}
+
+bool UnityAssertEqualUInt32(uint32_t expected, uint32_t actual, unsigned int line_number)
+{
+    if (expected == actual)
+        return true;
+
+    char buffer[128];
+    (void)snprintf(buffer, sizeof(buffer), "Expected %" PRIu32 " but was %" PRIu32, expected, actual);
+    UnityFail(buffer, line_number);
+    return false;
+}
+
+bool UnityAssertStringEqual(const char *expected, const char *actual, unsigned int line_number)
+{
+    if (expected == NULL && actual == NULL)
+        return true;
+
+    if (expected != NULL && actual != NULL && strcmp(expected, actual) == 0)
+        return true;
+
+    char buffer[256];
+    (void)snprintf(buffer, sizeof(buffer), "Expected '%s' but was '%s'",
+                   expected ? expected : "(null)",
+                   actual ? actual : "(null)");
+    UnityFail(buffer, line_number);
+    return false;
+}
+
+bool UnityAssertLessOrEqualUInt32(uint32_t expected, uint32_t actual, unsigned int line_number)
+{
+    if (actual <= expected)
+        return true;
+
+    char buffer[128];
+    (void)snprintf(buffer, sizeof(buffer), "Expected <= %" PRIu32 " but was %" PRIu32, expected, actual);
+    UnityFail(buffer, line_number);
+    return false;
+}
+
+void UnityDefaultTestRun(UnityTestFunction func, const char *name, int line_number)
+{
+    Unity.total_tests++;
+    Unity.current_test_name = name;
+    Unity.current_test_line = (unsigned int)line_number;
+    Unity.current_test_failed = false;
+
+    unity_print_test_header(name);
+
+    setUp();
+    func();
+    tearDown();
+
+    if (Unity.current_test_failed)
+    {
+        Unity.failed_tests++;
+    }
+
+    unity_print_test_result(name, Unity.current_test_failed);
+}

--- a/esp32_mcu/tests_host/unity/unity.c
+++ b/esp32_mcu/tests_host/unity/unity.c
@@ -6,6 +6,71 @@
 
 UnityContext Unity = {0};
 
+static const char *unity_filter = NULL;
+static bool unity_list_only = false;
+static bool unity_filter_includes(const char *name)
+{
+    if (!unity_filter || !name)
+    {
+        return true;
+    }
+
+    return strstr(name, unity_filter) != NULL;
+}
+
+void UnityConfigureFromArgs(int argc, const char *argv[])
+{
+    unity_filter = NULL;
+    unity_list_only = false;
+
+    if (argc <= 1 || !argv)
+        return;
+
+    for (int i = 1; i < argc; ++i)
+    {
+        const char *arg = argv[i];
+        if (!arg)
+            continue;
+
+        if (strncmp(arg, "--filter=", 9) == 0)
+        {
+            unity_filter = arg + 9;
+        }
+        else if (strcmp(arg, "--filter") == 0)
+        {
+            if (i + 1 < argc)
+            {
+                unity_filter = argv[++i];
+            }
+            else
+            {
+                fprintf(stderr, "Unity: missing value for --filter option\n");
+            }
+        }
+        else if (strcmp(arg, "--list") == 0)
+        {
+            unity_list_only = true;
+        }
+        else if (strcmp(arg, "--help") == 0 || strcmp(arg, "-h") == 0)
+        {
+            printf("Unity host test options:\n");
+            printf("  --filter <substring>   Run only tests whose name contains the substring.\n");
+            printf("  --list                 Print discovered test names without executing them.\n");
+            printf("  --help                 Show this message.\n");
+            unity_list_only = true;
+        }
+        else
+        {
+            fprintf(stderr, "Unity: ignoring unknown option '%s'\n", arg);
+        }
+    }
+}
+
+bool UnityIsListing(void)
+{
+    return unity_list_only;
+}
+
 extern void setUp(void);
 extern void tearDown(void);
 
@@ -131,6 +196,20 @@ bool UnityAssertLessOrEqualUInt32(uint32_t expected, uint32_t actual, unsigned i
 
 void UnityDefaultTestRun(UnityTestFunction func, const char *name, int line_number)
 {
+    if (unity_list_only)
+    {
+        if (unity_filter_includes(name))
+        {
+            printf("%s\n", name ? name : "<unnamed>");
+        }
+        return;
+    }
+
+    if (!unity_filter_includes(name))
+    {
+        return;
+    }
+
     Unity.total_tests++;
     Unity.current_test_name = name;
     Unity.current_test_line = (unsigned int)line_number;

--- a/esp32_mcu/tests_host/unity/unity.h
+++ b/esp32_mcu/tests_host/unity/unity.h
@@ -30,6 +30,8 @@ bool UnityAssertEqualUInt32(uint32_t expected, uint32_t actual, unsigned int lin
 bool UnityAssertStringEqual(const char *expected, const char *actual, unsigned int line_number);
 bool UnityAssertLessOrEqualUInt32(uint32_t expected, uint32_t actual, unsigned int line_number);
 void UnityMessage(const char *message, unsigned int line_number);
+void UnityConfigureFromArgs(int argc, const char *argv[]);
+bool UnityIsListing(void);
 
 #define UNITY_BEGIN() (UnityBegin(__FILE__))
 #define UNITY_END() (UnityEnd())

--- a/esp32_mcu/tests_host/unity/unity.h
+++ b/esp32_mcu/tests_host/unity/unity.h
@@ -1,0 +1,106 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void (*UnityTestFunction)(void);
+
+typedef struct UnityContext {
+    unsigned int total_tests;
+    unsigned int failed_tests;
+    const char *current_test_name;
+    unsigned int current_test_line;
+    const char *current_test_file;
+    bool current_test_failed;
+} UnityContext;
+
+extern UnityContext Unity;
+
+void UnityBegin(const char *filename);
+int UnityEnd(void);
+void UnityDefaultTestRun(UnityTestFunction func, const char *name, int line_number);
+void UnityFail(const char *message, unsigned int line_number);
+bool UnityAssert(bool condition, const char *message, unsigned int line_number);
+bool UnityAssertEqualInt(long expected, long actual, unsigned int line_number);
+bool UnityAssertEqualUInt32(uint32_t expected, uint32_t actual, unsigned int line_number);
+bool UnityAssertStringEqual(const char *expected, const char *actual, unsigned int line_number);
+bool UnityAssertLessOrEqualUInt32(uint32_t expected, uint32_t actual, unsigned int line_number);
+void UnityMessage(const char *message, unsigned int line_number);
+
+#define UNITY_BEGIN() (UnityBegin(__FILE__))
+#define UNITY_END() (UnityEnd())
+#define RUN_TEST(func) (UnityDefaultTestRun((func), #func, __LINE__))
+
+#define UNITY_TEST_ASSERT(condition, message, line)                             \
+    do {                                                                         \
+        if (!(UnityAssert((condition), (message), (line)))) {                    \
+            return;                                                             \
+        }                                                                        \
+    } while (0)
+
+#define UNITY_TEST_FAIL(message, line)                                          \
+    do {                                                                         \
+        UnityFail((message), (line));                                           \
+        return;                                                                 \
+    } while (0)
+
+#define TEST_ASSERT(condition)                                                  \
+    UNITY_TEST_ASSERT((condition), "Condition was false", __LINE__)
+
+#define TEST_ASSERT_TRUE(condition)                                             \
+    UNITY_TEST_ASSERT((condition), "Expected true", __LINE__)
+
+#define TEST_ASSERT_FALSE(condition)                                            \
+    UNITY_TEST_ASSERT(!(condition), "Expected false", __LINE__)
+
+#define TEST_ASSERT_NULL(pointer)                                               \
+    UNITY_TEST_ASSERT((pointer) == NULL, "Expected NULL", __LINE__)
+
+#define TEST_ASSERT_NOT_NULL(pointer)                                           \
+    UNITY_TEST_ASSERT((pointer) != NULL, "Expected non-NULL", __LINE__)
+
+#define TEST_ASSERT_EQUAL_INT(expected, actual)                                 \
+    do {                                                                         \
+        if (!UnityAssertEqualInt((expected), (actual), __LINE__)) {             \
+            return;                                                             \
+        }                                                                        \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_UINT32(expected, actual)                              \
+    do {                                                                         \
+        if (!UnityAssertEqualUInt32((expected), (actual), __LINE__)) {          \
+            return;                                                             \
+        }                                                                        \
+    } while (0)
+
+#define TEST_ASSERT_EQUAL_STRING(expected, actual)                              \
+    do {                                                                         \
+        if (!UnityAssertStringEqual((expected), (actual), __LINE__)) {          \
+            return;                                                             \
+        }                                                                        \
+    } while (0)
+
+#define TEST_ASSERT_LESS_OR_EQUAL_UINT32(expected, actual)                      \
+    do {                                                                         \
+        if (!UnityAssertLessOrEqualUInt32((expected), (actual), __LINE__)) {    \
+            return;                                                             \
+        }                                                                        \
+    } while (0)
+
+#define TEST_FAIL_MESSAGE(message)                                              \
+    UNITY_TEST_FAIL((message), __LINE__)
+
+#define TEST_IGNORE()                                                           \
+    return
+
+#define TEST_MESSAGE(message)                                                   \
+    UnityMessage((message), __LINE__)
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
## Summary
- create a standalone CMake project under tests_host to build host unit tests without the ESP-IDF toolchain
- bundle a lightweight Unity implementation to drive the existing Unity-style test cases on the PC
- add minimal ESP-IDF mock headers so production code can be compiled and tested on the host

## Testing
- cmake --build esp32_mcu/tests_host/build
- ctest --test-dir esp32_mcu/tests_host/build


------
https://chatgpt.com/codex/tasks/task_e_68c86851a768832eb6268b93406e52ae