### PR TITLE
Implement NVS-backed clients module

### DIFF
--- a/esp32_mcu/components/clients/CMakeLists.txt
+++ b/esp32_mcu/components/clients/CMakeLists.txt
@@ -6,4 +6,5 @@ idf_component_register(
     SRCS ${srcs}
     INCLUDE_DIRS .
     REQUIRES common
+    PRIV_REQUIRES nvs_flash
 )

--- a/esp32_mcu/components/clients/clients.c
+++ b/esp32_mcu/components/clients/clients.c
@@ -1,20 +1,522 @@
 #include "clients.h"
 
-static bool db_opened = false;
+#include <string.h>
+
+#include "esp_err.h"
+#include "esp_log.h"
+#include "nvs.h"
+#include "nvs_flash.h"
+
+#define CLIENTS_STORAGE_KEY "table"
+
+static const char *TAG = "clients";
+
+typedef struct
+{
+    uint32_t count;
+    client_t records[CLIENTS_DB_MAX_RECORDS];
+} clients_storage_t;
+
+typedef struct
+{
+    bool             initialized;
+    nvs_handle_t     handle;
+    clients_storage_t storage;
+} clients_db_t;
+
+static clients_db_t g_db;
+
+static clients_status_t ensure_initialized(void);
+static clients_status_t load_storage(void);
+static clients_status_t persist_storage(void);
+static int              find_client_index(const client_uid_t client_id);
+static bool             client_id_is_empty(const client_uid_t client_id);
+static bool             string_has_terminator(const char *str, size_t capacity);
+static clients_status_t validate_client(const client_t *client);
+static void             copy_client_record(client_t *dst, const client_t *src);
+static bool             get_bit(uint8_t flags, uint8_t bit_num);
+static uint8_t          set_bit(uint8_t flags, uint8_t bit_num, bool value);
+static clients_status_t update_allow_bit(const client_uid_t client_id, uint8_t bit_num, bool value);
 
 clients_status_t open_client_db(void)
 {
-    if (db_opened)
+    if (g_db.initialized)
         return CLIENTS_OK;
 
-    db_opened = true;
-    return CLIENTS_ERR_NO_INIT;
+    esp_err_t err = nvs_flash_init();
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND)
+    {
+        if (nvs_flash_erase() != ESP_OK)
+        {
+            ESP_LOGE(TAG, "%s", "failed to erase NVS flash");
+            return CLIENTS_ERR_STORAGE;
+        }
+        err = nvs_flash_init();
+    }
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "nvs_flash_init failed: %s", esp_err_to_name(err));
+        return CLIENTS_ERR_STORAGE;
+    }
+
+    err = nvs_open(CLIENTS_DB_NAMESPACE, NVS_READWRITE, &g_db.handle);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "nvs_open failed: %s", esp_err_to_name(err));
+        return CLIENTS_ERR_STORAGE;
+    }
+
+    clients_status_t status = load_storage();
+    if (status != CLIENTS_OK)
+    {
+        nvs_close(g_db.handle);
+        g_db.handle      = NULL;
+        g_db.initialized = false;
+        return status;
+    }
+
+    g_db.initialized = true;
+    return CLIENTS_OK;
 }
 
 void close_client_db(void)
 {
-    if (false == db_opened)
+    if (!g_db.initialized)
         return;
 
-    db_opened = false;
+    nvs_close(g_db.handle);
+    g_db.handle      = NULL;
+    g_db.initialized = false;
+    memset(&g_db.storage, 0, sizeof(g_db.storage));
+}
+
+clients_status_t clients_add(const client_t *client)
+{
+    clients_status_t status = ensure_initialized();
+    if (status != CLIENTS_OK)
+        return status;
+    status = validate_client(client);
+    if (status != CLIENTS_OK)
+        return status;
+
+    if (g_db.storage.count >= CLIENTS_DB_MAX_RECORDS)
+        return CLIENTS_ERR_FULL;
+
+    if (find_client_index(client->client_id) >= 0)
+        return CLIENTS_ERR_EXISTS;
+
+    client_t  record;
+    uint32_t  index = g_db.storage.count;
+
+    copy_client_record(&record, client);
+    g_db.storage.records[index] = record;
+    g_db.storage.count++;
+
+    status = persist_storage();
+    if (status != CLIENTS_OK)
+    {
+        g_db.storage.count--;
+        memset(&g_db.storage.records[index], 0, sizeof(client_t));
+    }
+
+    return status;
+}
+
+clients_status_t clients_get(const client_uid_t client_id, const client_t **out_client)
+{
+    if (NULL == out_client)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    clients_status_t status = ensure_initialized();
+    if (status != CLIENTS_OK)
+        return status;
+
+    if (NULL == client_id)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    int index = find_client_index(client_id);
+    if (index < 0)
+        return CLIENTS_ERR_NOT_FOUND;
+
+    *out_client = &g_db.storage.records[index];
+    return CLIENTS_OK;
+}
+
+clients_status_t clients_get_name(const client_uid_t client_id, char *buffer, size_t buffer_size)
+{
+    if ((NULL == buffer) || (0U == buffer_size))
+        return CLIENTS_ERR_INVALID_ARG;
+
+    const client_t *client = NULL;
+    clients_status_t status = clients_get(client_id, &client);
+    if (status != CLIENTS_OK)
+        return status;
+
+    size_t length = 0;
+    while ((length < CLIENTS_NAME_MAX) && (client->name[length] != '\0'))
+        ++length;
+
+    if (length >= buffer_size)
+        return CLIENTS_ERR_TOO_LONG;
+
+    memcpy(buffer, client->name, length);
+    buffer[length] = '\0';
+    return CLIENTS_OK;
+}
+
+clients_status_t clients_get_pub_pem(const client_uid_t client_id, char *buffer, size_t buffer_size)
+{
+    if ((NULL == buffer) || (0U == buffer_size))
+        return CLIENTS_ERR_INVALID_ARG;
+
+    const client_t *client = NULL;
+    clients_status_t status = clients_get(client_id, &client);
+    if (status != CLIENTS_OK)
+        return status;
+
+    size_t length = 0;
+    while ((length < CLIENTS_PUBPEM_CAP) && (client->pub_pem[length] != '\0'))
+        ++length;
+
+    if (length >= buffer_size)
+        return CLIENTS_ERR_TOO_LONG;
+
+    memcpy(buffer, client->pub_pem, length);
+    buffer[length] = '\0';
+    return CLIENTS_OK;
+}
+
+clients_status_t clients_get_nonce(const client_uid_t client_id, nonce_t *nonce)
+{
+    if (NULL == nonce)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    const client_t *client = NULL;
+    clients_status_t status = clients_get(client_id, &client);
+    if (status != CLIENTS_OK)
+        return status;
+
+    *nonce = client->nonce;
+    return CLIENTS_OK;
+}
+
+clients_status_t clients_set_nonce(const client_uid_t client_id, nonce_t nonce)
+{
+    clients_status_t status = ensure_initialized();
+    if (status != CLIENTS_OK)
+        return status;
+
+    if (NULL == client_id)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    int index = find_client_index(client_id);
+    if (index < 0)
+        return CLIENTS_ERR_NOT_FOUND;
+
+    nonce_t old_value = g_db.storage.records[index].nonce;
+    g_db.storage.records[index].nonce = nonce;
+
+    status = persist_storage();
+    if (status != CLIENTS_OK)
+        g_db.storage.records[index].nonce = old_value;
+
+    return status;
+}
+
+clients_status_t clients_get_allow_flags(const client_uid_t client_id, uint8_t *flags)
+{
+    if (NULL == flags)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    const client_t *client = NULL;
+    clients_status_t status = clients_get(client_id, &client);
+    if (status != CLIENTS_OK)
+        return status;
+
+    *flags = client->allow_flags;
+    return CLIENTS_OK;
+}
+
+clients_status_t clients_set_allow_flags(const client_uid_t client_id, uint8_t flags)
+{
+    clients_status_t status = ensure_initialized();
+    if (status != CLIENTS_OK)
+        return status;
+
+    if (NULL == client_id)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    int index = find_client_index(client_id);
+    if (index < 0)
+        return CLIENTS_ERR_NOT_FOUND;
+
+    uint8_t old_flags = g_db.storage.records[index].allow_flags;
+    g_db.storage.records[index].allow_flags = flags;
+
+    status = persist_storage();
+    if (status != CLIENTS_OK)
+        g_db.storage.records[index].allow_flags = old_flags;
+
+    return status;
+}
+
+clients_status_t clients_allow_bluetooth_get(const client_uid_t client_id, bool *allowed)
+{
+    if (NULL == allowed)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    const client_t *client = NULL;
+    clients_status_t status = clients_get(client_id, &client);
+    if (status != CLIENTS_OK)
+        return status;
+
+    *allowed = get_bit(client->allow_flags, CLIENTS_ALLOW_FLAG_BLUETOOTH);
+    return CLIENTS_OK;
+}
+
+clients_status_t clients_allow_bluetooth_set(const client_uid_t client_id, bool allowed)
+{
+    return update_allow_bit(client_id, CLIENTS_ALLOW_FLAG_BLUETOOTH, allowed);
+}
+
+clients_status_t clients_allow_public_mqtt_get(const client_uid_t client_id, bool *allowed)
+{
+    if (NULL == allowed)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    const client_t *client = NULL;
+    clients_status_t status = clients_get(client_id, &client);
+    if (status != CLIENTS_OK)
+        return status;
+
+    *allowed = get_bit(client->allow_flags, CLIENTS_ALLOW_FLAG_PUBLIC_MQTT);
+    return CLIENTS_OK;
+}
+
+clients_status_t clients_allow_public_mqtt_set(const client_uid_t client_id, bool allowed)
+{
+    return update_allow_bit(client_id, CLIENTS_ALLOW_FLAG_PUBLIC_MQTT, allowed);
+}
+
+clients_status_t clients_get_ids(client_uid_t *out_ids, size_t max_ids, size_t *out_count)
+{
+    clients_status_t status = ensure_initialized();
+    if (status != CLIENTS_OK)
+        return status;
+
+    if (NULL == out_count)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    *out_count = g_db.storage.count;
+
+    if (0U == g_db.storage.count)
+        return CLIENTS_OK;
+
+    if ((NULL == out_ids) || (max_ids < g_db.storage.count))
+        return CLIENTS_ERR_TOO_LONG;
+
+    for (uint32_t i = 0; i < g_db.storage.count; ++i)
+    {
+        memcpy(out_ids[i], g_db.storage.records[i].client_id, sizeof(client_uid_t));
+    }
+
+    return CLIENTS_OK;
+}
+
+size_t clients_size(void)
+{
+    if (!g_db.initialized)
+        return 0U;
+
+    return (size_t)g_db.storage.count;
+}
+
+static clients_status_t ensure_initialized(void)
+{
+    if (!g_db.initialized)
+        return CLIENTS_ERR_NO_INIT;
+    return CLIENTS_OK;
+}
+
+static clients_status_t load_storage(void)
+{
+    memset(&g_db.storage, 0, sizeof(g_db.storage));
+
+    size_t required_size = 0;
+    esp_err_t err = nvs_get_blob(g_db.handle, CLIENTS_STORAGE_KEY, NULL, &required_size);
+    if (err == ESP_ERR_NVS_NOT_FOUND)
+    {
+        return persist_storage();
+    }
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "nvs_get_blob size failed: %s", esp_err_to_name(err));
+        return CLIENTS_ERR_STORAGE;
+    }
+    if (required_size < sizeof(uint32_t))
+    {
+        ESP_LOGE(TAG, "%s", "stored clients blob too small");
+        return CLIENTS_ERR_STORAGE;
+    }
+    if (required_size > sizeof(g_db.storage))
+    {
+        ESP_LOGE(TAG, "stored clients blob too large (%zu)", required_size);
+        return CLIENTS_ERR_STORAGE;
+    }
+
+    size_t copy_size = sizeof(g_db.storage);
+    err              = nvs_get_blob(g_db.handle, CLIENTS_STORAGE_KEY, &g_db.storage, &copy_size);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "nvs_get_blob data failed: %s", esp_err_to_name(err));
+        return CLIENTS_ERR_STORAGE;
+    }
+
+    if (g_db.storage.count > CLIENTS_DB_MAX_RECORDS)
+        g_db.storage.count = CLIENTS_DB_MAX_RECORDS;
+
+    return CLIENTS_OK;
+}
+
+static clients_status_t persist_storage(void)
+{
+    size_t stored_size = sizeof(g_db.storage.count) + (size_t)g_db.storage.count * sizeof(client_t);
+    if (stored_size < sizeof(uint32_t))
+        stored_size = sizeof(uint32_t);
+
+    esp_err_t err = nvs_set_blob(g_db.handle, CLIENTS_STORAGE_KEY, &g_db.storage, stored_size);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "nvs_set_blob failed: %s", esp_err_to_name(err));
+        return CLIENTS_ERR_STORAGE;
+    }
+
+    err = nvs_commit(g_db.handle);
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "nvs_commit failed: %s", esp_err_to_name(err));
+        return CLIENTS_ERR_STORAGE;
+    }
+
+    return CLIENTS_OK;
+}
+
+static int find_client_index(const client_uid_t client_id)
+{
+    if (NULL == client_id)
+        return -1;
+
+    for (uint32_t i = 0; i < g_db.storage.count; ++i)
+    {
+        if (0 == memcmp(g_db.storage.records[i].client_id, client_id, sizeof(client_uid_t)))
+            return (int)i;
+    }
+
+    return -1;
+}
+
+static bool client_id_is_empty(const client_uid_t client_id)
+{
+    for (size_t i = 0; i < sizeof(client_uid_t); ++i)
+    {
+        if (client_id[i] != 0U)
+            return false;
+    }
+    return true;
+}
+
+static bool string_has_terminator(const char *str, size_t capacity)
+{
+    for (size_t i = 0; i < capacity; ++i)
+    {
+        if ('\0' == str[i])
+            return true;
+    }
+    return false;
+}
+
+static clients_status_t validate_client(const client_t *client)
+{
+    if (NULL == client)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    if (client_id_is_empty(client->client_id))
+        return CLIENTS_ERR_INVALID_ARG;
+
+    if (!string_has_terminator(client->name, CLIENTS_NAME_MAX))
+        return CLIENTS_ERR_TOO_LONG;
+
+    if (!string_has_terminator(client->pub_pem, CLIENTS_PUBPEM_CAP))
+        return CLIENTS_ERR_TOO_LONG;
+
+    return CLIENTS_OK;
+}
+
+static void copy_client_record(client_t *dst, const client_t *src)
+{
+    memset(dst, 0, sizeof(*dst));
+    dst->allow_flags = src->allow_flags;
+    dst->nonce       = src->nonce;
+    memcpy(dst->client_id, src->client_id, sizeof(client_uid_t));
+
+    size_t name_len = 0;
+    while ((name_len < (CLIENTS_NAME_MAX - 1U)) && (src->name[name_len] != '\0'))
+        ++name_len;
+    if (name_len > 0U)
+        memcpy(dst->name, src->name, name_len);
+    dst->name[name_len] = '\0';
+
+    size_t pem_len = 0;
+    while ((pem_len < (CLIENTS_PUBPEM_CAP - 1U)) && (src->pub_pem[pem_len] != '\0'))
+        ++pem_len;
+    if (pem_len > 0U)
+        memcpy(dst->pub_pem, src->pub_pem, pem_len);
+    dst->pub_pem[pem_len] = '\0';
+}
+
+static bool get_bit(uint8_t flags, uint8_t bit_num)
+{
+    if (bit_num >= 8U)
+        return false;
+
+    return ((flags >> bit_num) & 0x01U) != 0U;
+}
+
+static uint8_t set_bit(uint8_t flags, uint8_t bit_num, bool value)
+{
+    if (bit_num >= 8U)
+        return flags;
+
+    uint8_t mask = (uint8_t)(1U << bit_num);
+    if (value)
+        return (uint8_t)(flags | mask);
+    return (uint8_t)(flags & (uint8_t)~mask);
+}
+
+static clients_status_t update_allow_bit(const client_uid_t client_id, uint8_t bit_num, bool value)
+{
+    clients_status_t status = ensure_initialized();
+    if (status != CLIENTS_OK)
+        return status;
+
+    if (NULL == client_id)
+        return CLIENTS_ERR_INVALID_ARG;
+
+    int index = find_client_index(client_id);
+    if (index < 0)
+        return CLIENTS_ERR_NOT_FOUND;
+
+    client_t *record   = &g_db.storage.records[index];
+    uint8_t  new_flags = set_bit(record->allow_flags, bit_num, value);
+    if (new_flags == record->allow_flags)
+        return CLIENTS_OK;
+
+    uint8_t old_flags = record->allow_flags;
+    record->allow_flags = new_flags;
+
+    status = persist_storage();
+    if (status != CLIENTS_OK)
+        record->allow_flags = old_flags;
+
+    return status;
 }

--- a/esp32_mcu/components/clients/clients.h
+++ b/esp32_mcu/components/clients/clients.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stdbool.h>
+#include <stddef.h>
+
 // include components
 #include "types.h"
 #include "constants.h"
@@ -49,6 +52,25 @@ typedef struct
 } client_t;
 
 
+// ---- Flag positions ----
+#define CLIENTS_ALLOW_FLAG_BLUETOOTH    0U
+#define CLIENTS_ALLOW_FLAG_PUBLIC_MQTT  1U
+
+
 // ---- API ----
 clients_status_t open_client_db(void);
 void close_client_db(void);
+clients_status_t clients_add(const client_t *client);
+clients_status_t clients_get(const client_uid_t client_id, const client_t **out_client);
+clients_status_t clients_get_name(const client_uid_t client_id, char *buffer, size_t buffer_size);
+clients_status_t clients_get_pub_pem(const client_uid_t client_id, char *buffer, size_t buffer_size);
+clients_status_t clients_get_nonce(const client_uid_t client_id, nonce_t *nonce);
+clients_status_t clients_set_nonce(const client_uid_t client_id, nonce_t nonce);
+clients_status_t clients_get_allow_flags(const client_uid_t client_id, uint8_t *flags);
+clients_status_t clients_set_allow_flags(const client_uid_t client_id, uint8_t flags);
+clients_status_t clients_allow_bluetooth_get(const client_uid_t client_id, bool *allowed);
+clients_status_t clients_allow_bluetooth_set(const client_uid_t client_id, bool allowed);
+clients_status_t clients_allow_public_mqtt_get(const client_uid_t client_id, bool *allowed);
+clients_status_t clients_allow_public_mqtt_set(const client_uid_t client_id, bool allowed);
+clients_status_t clients_get_ids(client_uid_t *out_ids, size_t max_ids, size_t *out_count);
+size_t clients_size(void);

--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -29,14 +29,27 @@ target_include_directories(unity
         ${CMAKE_CURRENT_LIST_DIR}/unity
 )
 
-# Interface library exposing ESP-IDF shims used when compiling production
+# Library exposing ESP-IDF shims used when compiling production
 # sources on the host.
-add_library(tapgate_idf_mocks INTERFACE)
+add_library(tapgate_idf_mocks STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/mock_nvs.c
+)
 
 target_include_directories(tapgate_idf_mocks
-    INTERFACE
+    PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/mocks/include
 )
+
+target_compile_features(tapgate_idf_mocks
+    PUBLIC
+        c_std_11
+)
+
+if(MSVC)
+    target_compile_options(tapgate_idf_mocks PRIVATE /W4)
+else()
+    target_compile_options(tapgate_idf_mocks PRIVATE -Wall -Wextra -Wpedantic)
+endif()
 
 # Static library with production sources that are safe to build on the host.
 add_library(tapgate_production STATIC)

--- a/esp32_mcu/tests_host/mocks/include/esp_err.h
+++ b/esp32_mcu/tests_host/mocks/include/esp_err.h
@@ -10,12 +10,18 @@ extern "C" {
 
 typedef int32_t esp_err_t;
 
-#define ESP_OK           0
-#define ESP_FAIL        -1
-#define ESP_ERR_NO_MEM   0x101
-#define ESP_ERR_INVALID_ARG 0x102
-#define ESP_ERR_NOT_FOUND   0x103
-#define ESP_ERR_TIMEOUT     0x104
+#define ESP_OK                     0
+#define ESP_FAIL                  -1
+#define ESP_ERR_NO_MEM             0x101
+#define ESP_ERR_INVALID_ARG        0x102
+#define ESP_ERR_NOT_FOUND          0x103
+#define ESP_ERR_TIMEOUT            0x104
+
+#define ESP_ERR_NVS_BASE           0x1100
+#define ESP_ERR_NVS_NOT_FOUND      (ESP_ERR_NVS_BASE + 1)
+#define ESP_ERR_NVS_INVALID_LENGTH (ESP_ERR_NVS_BASE + 2)
+#define ESP_ERR_NVS_NO_FREE_PAGES  (ESP_ERR_NVS_BASE + 3)
+#define ESP_ERR_NVS_NEW_VERSION_FOUND (ESP_ERR_NVS_BASE + 4)
 
 static inline const char *esp_err_to_name(esp_err_t code)
 {
@@ -33,6 +39,14 @@ static inline const char *esp_err_to_name(esp_err_t code)
             return "ESP_ERR_NOT_FOUND";
         case ESP_ERR_TIMEOUT:
             return "ESP_ERR_TIMEOUT";
+        case ESP_ERR_NVS_NOT_FOUND:
+            return "ESP_ERR_NVS_NOT_FOUND";
+        case ESP_ERR_NVS_INVALID_LENGTH:
+            return "ESP_ERR_NVS_INVALID_LENGTH";
+        case ESP_ERR_NVS_NO_FREE_PAGES:
+            return "ESP_ERR_NVS_NO_FREE_PAGES";
+        case ESP_ERR_NVS_NEW_VERSION_FOUND:
+            return "ESP_ERR_NVS_NEW_VERSION_FOUND";
         default:
             return "ESP_ERR_UNKNOWN";
     }

--- a/esp32_mcu/tests_host/mocks/include/nvs.h
+++ b/esp32_mcu/tests_host/mocks/include/nvs.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include <stddef.h>
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef void *nvs_handle_t;
+
+typedef enum {
+    NVS_READONLY = 0,
+    NVS_READWRITE = 1,
+} nvs_open_mode_t;
+
+esp_err_t nvs_open(const char *name, nvs_open_mode_t open_mode, nvs_handle_t *out_handle);
+void      nvs_close(nvs_handle_t handle);
+esp_err_t nvs_set_blob(nvs_handle_t handle, const char *key, const void *value, size_t length);
+esp_err_t nvs_get_blob(nvs_handle_t handle, const char *key, void *out_value, size_t *length);
+esp_err_t nvs_erase_key(nvs_handle_t handle, const char *key);
+esp_err_t nvs_commit(nvs_handle_t handle);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp32_mcu/tests_host/mocks/include/nvs_flash.h
+++ b/esp32_mcu/tests_host/mocks/include/nvs_flash.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+esp_err_t nvs_flash_init(void);
+esp_err_t nvs_flash_deinit(void);
+esp_err_t nvs_flash_erase(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/esp32_mcu/tests_host/mocks/mock_nvs.c
+++ b/esp32_mcu/tests_host/mocks/mock_nvs.c
@@ -1,0 +1,226 @@
+#include "nvs.h"
+#include "nvs_flash.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#define MOCK_NVS_MAX_NAMESPACES      8
+#define MOCK_NVS_MAX_KEYS            128
+#define MOCK_NVS_MAX_BLOB_SIZE       32768
+#define MOCK_NVS_MAX_KEY_LENGTH      15
+#define MOCK_NVS_MAX_NAMESPACE_LENGTH 15
+
+typedef struct
+{
+    bool    used;
+    char    key[MOCK_NVS_MAX_KEY_LENGTH + 1];
+    size_t  length;
+    uint8_t value[MOCK_NVS_MAX_BLOB_SIZE];
+} mock_nvs_entry_t;
+
+typedef struct
+{
+    bool             used;
+    char             name[MOCK_NVS_MAX_NAMESPACE_LENGTH + 1];
+    mock_nvs_entry_t entries[MOCK_NVS_MAX_KEYS];
+} mock_nvs_namespace_t;
+
+static mock_nvs_namespace_t g_namespaces[MOCK_NVS_MAX_NAMESPACES];
+static bool                 g_initialized;
+
+static mock_nvs_namespace_t *find_namespace(const char *name, bool create);
+static mock_nvs_entry_t     *find_entry(mock_nvs_namespace_t *ns, const char *key, bool create);
+static size_t                local_strnlen(const char *str, size_t max_len);
+
+esp_err_t nvs_flash_init(void)
+{
+    g_initialized = true;
+    return ESP_OK;
+}
+
+esp_err_t nvs_flash_deinit(void)
+{
+    g_initialized = false;
+    return ESP_OK;
+}
+
+esp_err_t nvs_flash_erase(void)
+{
+    memset(g_namespaces, 0, sizeof(g_namespaces));
+    return ESP_OK;
+}
+
+esp_err_t nvs_open(const char *name, nvs_open_mode_t open_mode, nvs_handle_t *out_handle)
+{
+    (void)open_mode;
+
+    if ((NULL == name) || (NULL == out_handle))
+        return ESP_ERR_INVALID_ARG;
+
+    size_t len = local_strnlen(name, MOCK_NVS_MAX_NAMESPACE_LENGTH + 1);
+    if ((len == 0U) || (len > MOCK_NVS_MAX_NAMESPACE_LENGTH))
+        return ESP_ERR_INVALID_ARG;
+
+    if (!g_initialized)
+        return ESP_ERR_INVALID_ARG;
+
+    mock_nvs_namespace_t *ns = find_namespace(name, true);
+    if (NULL == ns)
+        return ESP_ERR_NO_MEM;
+
+    *out_handle = (nvs_handle_t)ns;
+    return ESP_OK;
+}
+
+void nvs_close(nvs_handle_t handle)
+{
+    (void)handle;
+}
+
+esp_err_t nvs_set_blob(nvs_handle_t handle, const char *key, const void *value, size_t length)
+{
+    if ((NULL == handle) || (NULL == key))
+        return ESP_ERR_INVALID_ARG;
+
+    if ((length > 0U) && (NULL == value))
+        return ESP_ERR_INVALID_ARG;
+
+    size_t key_len = local_strnlen(key, MOCK_NVS_MAX_KEY_LENGTH + 1);
+    if ((key_len == 0U) || (key_len > MOCK_NVS_MAX_KEY_LENGTH))
+        return ESP_ERR_INVALID_ARG;
+
+    if (length > MOCK_NVS_MAX_BLOB_SIZE)
+        return ESP_ERR_NVS_INVALID_LENGTH;
+
+    mock_nvs_entry_t *entry = find_entry((mock_nvs_namespace_t *)handle, key, true);
+    if (NULL == entry)
+        return ESP_ERR_NO_MEM;
+
+    entry->length = length;
+    if (length > 0U)
+        memcpy(entry->value, value, length);
+
+    return ESP_OK;
+}
+
+esp_err_t nvs_get_blob(nvs_handle_t handle, const char *key, void *out_value, size_t *length)
+{
+    if ((NULL == handle) || (NULL == key) || (NULL == length))
+        return ESP_ERR_INVALID_ARG;
+
+    size_t key_len = local_strnlen(key, MOCK_NVS_MAX_KEY_LENGTH + 1);
+    if ((key_len == 0U) || (key_len > MOCK_NVS_MAX_KEY_LENGTH))
+        return ESP_ERR_INVALID_ARG;
+
+    mock_nvs_entry_t *entry = find_entry((mock_nvs_namespace_t *)handle, key, false);
+    if (NULL == entry)
+        return ESP_ERR_NVS_NOT_FOUND;
+
+    if (NULL == out_value)
+    {
+        *length = entry->length;
+        return ESP_OK;
+    }
+
+    if (*length < entry->length)
+    {
+        *length = entry->length;
+        return ESP_ERR_NVS_INVALID_LENGTH;
+    }
+
+    if (entry->length > 0U)
+        memcpy(out_value, entry->value, entry->length);
+    *length = entry->length;
+
+    return ESP_OK;
+}
+
+esp_err_t nvs_erase_key(nvs_handle_t handle, const char *key)
+{
+    if ((NULL == handle) || (NULL == key))
+        return ESP_ERR_INVALID_ARG;
+
+    mock_nvs_entry_t *entry = find_entry((mock_nvs_namespace_t *)handle, key, false);
+    if (NULL == entry)
+        return ESP_ERR_NVS_NOT_FOUND;
+
+    memset(entry, 0, sizeof(*entry));
+    return ESP_OK;
+}
+
+esp_err_t nvs_commit(nvs_handle_t handle)
+{
+    (void)handle;
+    return ESP_OK;
+}
+
+static size_t local_strnlen(const char *str, size_t max_len)
+{
+    size_t len = 0U;
+    if (NULL == str)
+        return 0U;
+
+    while ((len < max_len) && (str[len] != '\0'))
+        ++len;
+    return len;
+}
+
+static mock_nvs_namespace_t *find_namespace(const char *name, bool create)
+{
+    for (size_t i = 0; i < MOCK_NVS_MAX_NAMESPACES; ++i)
+    {
+        mock_nvs_namespace_t *ns = &g_namespaces[i];
+        if (ns->used && (strncmp(ns->name, name, MOCK_NVS_MAX_NAMESPACE_LENGTH) == 0))
+            return ns;
+    }
+
+    if (!create)
+        return NULL;
+
+    for (size_t i = 0; i < MOCK_NVS_MAX_NAMESPACES; ++i)
+    {
+        mock_nvs_namespace_t *ns = &g_namespaces[i];
+        if (!ns->used)
+        {
+            memset(ns, 0, sizeof(*ns));
+            ns->used = true;
+            strncpy(ns->name, name, MOCK_NVS_MAX_NAMESPACE_LENGTH);
+            ns->name[MOCK_NVS_MAX_NAMESPACE_LENGTH] = '\0';
+            return ns;
+        }
+    }
+
+    return NULL;
+}
+
+static mock_nvs_entry_t *find_entry(mock_nvs_namespace_t *ns, const char *key, bool create)
+{
+    if (NULL == ns)
+        return NULL;
+
+    for (size_t i = 0; i < MOCK_NVS_MAX_KEYS; ++i)
+    {
+        mock_nvs_entry_t *entry = &ns->entries[i];
+        if (entry->used && (strncmp(entry->key, key, MOCK_NVS_MAX_KEY_LENGTH) == 0))
+            return entry;
+    }
+
+    if (!create)
+        return NULL;
+
+    for (size_t i = 0; i < MOCK_NVS_MAX_KEYS; ++i)
+    {
+        mock_nvs_entry_t *entry = &ns->entries[i];
+        if (!entry->used)
+        {
+            memset(entry, 0, sizeof(*entry));
+            entry->used = true;
+            strncpy(entry->key, key, MOCK_NVS_MAX_KEY_LENGTH);
+            entry->key[MOCK_NVS_MAX_KEY_LENGTH] = '\0';
+            return entry;
+        }
+    }
+
+    return NULL;
+}

--- a/esp32_mcu/tests_host/test_clients.c
+++ b/esp32_mcu/tests_host/test_clients.c
@@ -1,13 +1,255 @@
 #include "unity.h"
 #include "clients/clients.h"
+#include "nvs_flash.h"
+
+#include <stdbool.h>
 #include <string.h>
 
-void setUp(void) {}
-void tearDown(void) {}
+static client_t make_client(const char *id, const char *name, const char *pem, nonce_t nonce, uint8_t flags);
+static void     copy_string(char *dest, size_t capacity, const char *src);
+static void     expect_client_id_equal(const client_uid_t expected, const client_uid_t actual);
+
+void setUp(void)
+{
+    close_client_db();
+    nvs_flash_deinit();
+    nvs_flash_erase();
+}
+
+void tearDown(void)
+{
+    close_client_db();
+    nvs_flash_deinit();
+    nvs_flash_erase();
+}
 
 void test_clients_namespace_length(void)
 {
     TEST_ASSERT_LESS_OR_EQUAL_UINT32(15, strlen(CLIENTS_DB_NAMESPACE));
+}
+
+void test_clients_requires_init(void)
+{
+    client_t sample = make_client("alpha", "Alpha", "PEM", 1U, 0U);
+    TEST_ASSERT_EQUAL_INT(CLIENTS_ERR_NO_INIT, clients_add(&sample));
+}
+
+void test_clients_open_close(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+    close_client_db();
+    close_client_db();
+}
+
+void test_clients_add_and_get(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t sample = make_client("client1", "Client One", "PEM1", 42U, 3U);
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&sample));
+
+    const client_t *retrieved = NULL;
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_get(sample.client_id, &retrieved));
+    TEST_ASSERT_NOT_NULL(retrieved);
+    TEST_ASSERT_EQUAL_UINT32(sample.allow_flags, retrieved->allow_flags);
+    TEST_ASSERT_EQUAL_UINT32(sample.nonce, retrieved->nonce);
+    TEST_ASSERT_EQUAL_STRING((const char *)sample.client_id, (const char *)retrieved->client_id);
+    TEST_ASSERT_EQUAL_STRING(sample.name, retrieved->name);
+    TEST_ASSERT_EQUAL_STRING(sample.pub_pem, retrieved->pub_pem);
+}
+
+void test_clients_add_duplicate(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t sample = make_client("dup", "Duplicate", "PEM", 5U, 0U);
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&sample));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_ERR_EXISTS, clients_add(&sample));
+}
+
+void test_clients_add_invalid_name(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t sample = make_client("badname", "Valid", "PEM", 1U, 0U);
+    memset(sample.name, 'A', CLIENTS_NAME_MAX);
+    sample.name[CLIENTS_NAME_MAX - 1U] = 'B';
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_ERR_TOO_LONG, clients_add(&sample));
+}
+
+void test_clients_get_unknown(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t sample = make_client("known", "Known", "PEM", 1U, 0U);
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&sample));
+
+    client_uid_t unknown;
+    copy_string((char *)unknown, sizeof(unknown), "unknown");
+
+    const client_t *retrieved = NULL;
+    TEST_ASSERT_EQUAL_INT(CLIENTS_ERR_NOT_FOUND, clients_get(unknown, &retrieved));
+    TEST_ASSERT_NULL(retrieved);
+}
+
+void test_clients_get_field_helpers(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t sample = make_client("fields", "Field User", "PEM DATA", 77U, 0x05U);
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&sample));
+
+    char name_buf[CLIENTS_NAME_MAX];
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_get_name(sample.client_id, name_buf, sizeof(name_buf)));
+    TEST_ASSERT_EQUAL_STRING(sample.name, name_buf);
+
+    char pem_buf[CLIENTS_PUBPEM_CAP];
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_get_pub_pem(sample.client_id, pem_buf, sizeof(pem_buf)));
+    TEST_ASSERT_EQUAL_STRING(sample.pub_pem, pem_buf);
+
+    nonce_t nonce = 0U;
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_get_nonce(sample.client_id, &nonce));
+    TEST_ASSERT_EQUAL_UINT32(sample.nonce, nonce);
+
+    uint8_t flags = 0U;
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_get_allow_flags(sample.client_id, &flags));
+    TEST_ASSERT_EQUAL_UINT32(sample.allow_flags, flags);
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_set_nonce(sample.client_id, 1234U));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_get_nonce(sample.client_id, &nonce));
+    TEST_ASSERT_EQUAL_UINT32(1234U, nonce);
+}
+
+void test_clients_allow_flags_helpers(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t sample = make_client("allow", "Allow", "PEM", 1U, 0U);
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&sample));
+
+    bool allowed = true;
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_allow_bluetooth_get(sample.client_id, &allowed));
+    TEST_ASSERT_FALSE(allowed);
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_allow_bluetooth_set(sample.client_id, true));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_allow_bluetooth_get(sample.client_id, &allowed));
+    TEST_ASSERT_TRUE(allowed);
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_allow_public_mqtt_set(sample.client_id, true));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_allow_public_mqtt_get(sample.client_id, &allowed));
+    TEST_ASSERT_TRUE(allowed);
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_allow_public_mqtt_set(sample.client_id, false));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_allow_public_mqtt_get(sample.client_id, &allowed));
+    TEST_ASSERT_FALSE(allowed);
+}
+
+void test_clients_get_ids(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t first  = make_client("id1", "One", "PEM1", 1U, 0U);
+    client_t second = make_client("id2", "Two", "PEM2", 2U, 1U);
+    client_t third  = make_client("id3", "Three", "PEM3", 3U, 2U);
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&first));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&second));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&third));
+
+    client_uid_t ids[3];
+    size_t       count = 0U;
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_get_ids(ids, 3U, &count));
+    TEST_ASSERT_EQUAL_UINT32(3U, count);
+    expect_client_id_equal(first.client_id, ids[0]);
+    expect_client_id_equal(second.client_id, ids[1]);
+    expect_client_id_equal(third.client_id, ids[2]);
+}
+
+void test_clients_get_ids_buffer_too_small(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t first  = make_client("id1", "One", "PEM1", 1U, 0U);
+    client_t second = make_client("id2", "Two", "PEM2", 2U, 1U);
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&first));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&second));
+
+    client_uid_t ids[1];
+    size_t       count = 0U;
+    TEST_ASSERT_EQUAL_INT(CLIENTS_ERR_TOO_LONG, clients_get_ids(ids, 1U, &count));
+    TEST_ASSERT_EQUAL_UINT32(2U, count);
+}
+
+void test_clients_size(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    TEST_ASSERT_EQUAL_UINT32(0U, clients_size());
+
+    client_t first  = make_client("id1", "One", "PEM1", 1U, 0U);
+    client_t second = make_client("id2", "Two", "PEM2", 2U, 1U);
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&first));
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&second));
+
+    TEST_ASSERT_EQUAL_UINT32(2U, clients_size());
+}
+
+void test_clients_persistence(void)
+{
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    client_t sample = make_client("persist", "Persist", "PEM", 11U, 0U);
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_add(&sample));
+
+    close_client_db();
+
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, open_client_db());
+
+    const client_t *retrieved = NULL;
+    TEST_ASSERT_EQUAL_INT(CLIENTS_OK, clients_get(sample.client_id, &retrieved));
+    TEST_ASSERT_NOT_NULL(retrieved);
+    TEST_ASSERT_EQUAL_STRING(sample.name, retrieved->name);
+}
+
+static client_t make_client(const char *id, const char *name, const char *pem, nonce_t nonce, uint8_t flags)
+{
+    client_t client;
+    memset(&client, 0, sizeof(client));
+    client.allow_flags = flags;
+    client.nonce       = nonce;
+    copy_string((char *)client.client_id, sizeof(client.client_id), id);
+    copy_string(client.name, sizeof(client.name), name);
+    copy_string(client.pub_pem, sizeof(client.pub_pem), pem);
+    return client;
+}
+
+static void copy_string(char *dest, size_t capacity, const char *src)
+{
+    if ((NULL == dest) || (0U == capacity))
+        return;
+
+    memset(dest, 0, capacity);
+
+    if (NULL == src)
+        return;
+
+    size_t index = 0U;
+    while ((index + 1U < capacity) && (src[index] != '\0'))
+    {
+        dest[index] = src[index];
+        ++index;
+    }
+
+    dest[index < capacity ? index : (capacity - 1U)] = '\0';
+}
+
+static void expect_client_id_equal(const client_uid_t expected, const client_uid_t actual)
+{
+    TEST_ASSERT_EQUAL_INT(0, memcmp(expected, actual, sizeof(client_uid_t)));
 }
 
 int main(int argc, char **argv)
@@ -15,5 +257,17 @@ int main(int argc, char **argv)
     UnityConfigureFromArgs(argc, (const char **)argv);
     UNITY_BEGIN();
     RUN_TEST(test_clients_namespace_length);
+    RUN_TEST(test_clients_requires_init);
+    RUN_TEST(test_clients_open_close);
+    RUN_TEST(test_clients_add_and_get);
+    RUN_TEST(test_clients_add_duplicate);
+    RUN_TEST(test_clients_add_invalid_name);
+    RUN_TEST(test_clients_get_unknown);
+    RUN_TEST(test_clients_get_field_helpers);
+    RUN_TEST(test_clients_allow_flags_helpers);
+    RUN_TEST(test_clients_get_ids);
+    RUN_TEST(test_clients_get_ids_buffer_too_small);
+    RUN_TEST(test_clients_size);
+    RUN_TEST(test_clients_persistence);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary
- implement a persistent clients database backed by NVS with helper getters, setters, and feature flag utilities
- add ESP-IDF NVS mock layer and expand host unit tests covering clients storage behaviours

## Testing
- cmake --preset host-tests
- cmake --build --preset host-tests
- ctest --preset host-tests

------
https://chatgpt.com/codex/tasks/task_e_68c9b86dae88832eb130bafda4033acc