### PR TITLE
Rename log wrapper APIs to LOG*

### DIFF
--- a/esp32_mcu/components/logs/CMakeLists.txt
+++ b/esp32_mcu/components/logs/CMakeLists.txt
@@ -1,0 +1,9 @@
+file(GLOB srcs
+    "${CMAKE_CURRENT_LIST_DIR}/*.c"
+)
+
+idf_component_register(
+    SRCS ${srcs}
+    INCLUDE_DIRS .
+    REQUIRES log
+)

--- a/esp32_mcu/components/logs/logs.c
+++ b/esp32_mcu/components/logs/logs.c
@@ -1,0 +1,82 @@
+#include "logs.h"
+
+#include "esp_log.h"
+
+#include <stdarg.h>
+#include <stdio.h>
+
+#ifndef LOGS_MESSAGE_BUFFER_SIZE
+#define LOGS_MESSAGE_BUFFER_SIZE 256
+#endif
+
+static void logs_vlog(esp_log_level_t level, const char *tag, const char *fmt, va_list args)
+{
+    char message[LOGS_MESSAGE_BUFFER_SIZE];
+    int written;
+
+    if (!fmt)
+        fmt = "";
+
+    written = vsnprintf(message, sizeof(message), fmt, args);
+    if (written < 0)
+    {
+        message[0] = '\0';
+    }
+    else if ((size_t)written >= sizeof(message))
+    {
+        message[sizeof(message) - 1] = '\0';
+    }
+
+    if (!tag)
+        tag = "";
+
+    switch (level)
+    {
+    case ESP_LOG_ERROR:
+        ESP_LOGE(tag, "%s", message);
+        break;
+    case ESP_LOG_WARN:
+        ESP_LOGW(tag, "%s", message);
+        break;
+    case ESP_LOG_INFO:
+        ESP_LOGI(tag, "%s", message);
+        break;
+    case ESP_LOG_DEBUG:
+    default:
+        ESP_LOGD(tag, "%s", message);
+        break;
+    }
+}
+
+void LOGD(const char *tag, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    logs_vlog(ESP_LOG_DEBUG, tag, fmt, args);
+    va_end(args);
+}
+
+void LOGI(const char *tag, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    logs_vlog(ESP_LOG_INFO, tag, fmt, args);
+    va_end(args);
+}
+
+void LOGW(const char *tag, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    logs_vlog(ESP_LOG_WARN, tag, fmt, args);
+    va_end(args);
+}
+
+void LOGE(const char *tag, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    logs_vlog(ESP_LOG_ERROR, tag, fmt, args);
+    va_end(args);
+}
+

--- a/esp32_mcu/components/logs/logs.h
+++ b/esp32_mcu/components/logs/logs.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void LOGD(const char *tag, const char *fmt, ...);
+void LOGI(const char *tag, const char *fmt, ...);
+void LOGW(const char *tag, const char *fmt, ...);
+void LOGE(const char *tag, const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -57,14 +57,13 @@ target_include_directories(tapgate_production
         ${CMAKE_CURRENT_LIST_DIR}/../components/rsapem
         ${CMAKE_CURRENT_LIST_DIR}/../components/clients
         ${CMAKE_CURRENT_LIST_DIR}/../components/common
+        ${CMAKE_CURRENT_LIST_DIR}/../components/logs
 )
 
 set(_tapgate_component_sources
     ${CMAKE_CURRENT_LIST_DIR}/../components/rsapem/rsapem.c
-)
-
-set(_tapgate_component_sources
     ${CMAKE_CURRENT_LIST_DIR}/../components/clients/clients.c
+    ${CMAKE_CURRENT_LIST_DIR}/../components/logs/logs.c
 )
 
 file(GLOB _tapgate_common_sources
@@ -147,4 +146,5 @@ endfunction()
 tapgate_add_unity_test(test_types ${CMAKE_CURRENT_LIST_DIR}/test_types.c)
 tapgate_add_unity_test(test_clients ${CMAKE_CURRENT_LIST_DIR}/test_clients.c)
 tapgate_add_unity_test(test_rsapem ${CMAKE_CURRENT_LIST_DIR}/test_rsapem.c)
+tapgate_add_unity_test(test_logs ${CMAKE_CURRENT_LIST_DIR}/test_logs.c)
 

--- a/esp32_mcu/tests_host/test_logs.c
+++ b/esp32_mcu/tests_host/test_logs.c
@@ -1,0 +1,148 @@
+#if !defined(_WIN32) && !defined(_POSIX_C_SOURCE)
+#define _POSIX_C_SOURCE 200809L
+#endif
+
+#include "unity.h"
+#include "logs/logs.h"
+
+#include <stdio.h>
+
+#if defined(_WIN32)
+#include <io.h>
+#define tg_dup   _dup
+#define tg_dup2  _dup2
+#define tg_fileno _fileno
+#define tg_close _close
+#else
+#include <unistd.h>
+#define tg_dup   dup
+#define tg_dup2  dup2
+#define tg_fileno fileno
+#define tg_close close
+#endif
+
+typedef void (*log_invoker_t)(void *context);
+
+static size_t capture_stream_output(FILE *stream, char *buffer, size_t buffer_size,
+                                    log_invoker_t invoker, void *context)
+{
+    if (!stream || !buffer || buffer_size == 0)
+        return 0;
+
+    fflush(stream);
+
+    int original_fd = tg_dup(tg_fileno(stream));
+    if (original_fd < 0)
+        return 0;
+
+    FILE *temp = tmpfile();
+    if (!temp)
+    {
+        tg_close(original_fd);
+        return 0;
+    }
+
+    int temp_fd = tg_fileno(temp);
+    if (temp_fd < 0)
+    {
+        fclose(temp);
+        tg_close(original_fd);
+        return 0;
+    }
+
+    if (tg_dup2(temp_fd, tg_fileno(stream)) < 0)
+    {
+        fclose(temp);
+        tg_close(original_fd);
+        return 0;
+    }
+
+    if (invoker)
+        invoker(context);
+
+    fflush(stream);
+    fflush(temp);
+
+    rewind(temp);
+    size_t read = fread(buffer, 1, buffer_size - 1, temp);
+    buffer[read] = '\0';
+
+    if (tg_dup2(original_fd, tg_fileno(stream)) < 0)
+        read = 0;
+
+    tg_close(original_fd);
+    fclose(temp);
+
+    return read;
+}
+
+static void invoke_LOGD(void *context)
+{
+    (void)context;
+    LOGD("debug-tag", "value=%d text=%s", 7, "alpha");
+}
+
+static void invoke_LOGI(void *context)
+{
+    (void)context;
+    LOGI("info-tag", "value=%d text=%s", 42, "beta");
+}
+
+static void invoke_LOGW(void *context)
+{
+    (void)context;
+    LOGW("warn-tag", "value=%d text=%s", -1, "gamma");
+}
+
+static void invoke_LOGE(void *context)
+{
+    (void)context;
+    LOGE("error-tag", "value=%d text=%s", 5, "delta");
+}
+
+void setUp(void) {}
+void tearDown(void) {}
+
+void test_LOGD_formats_message(void)
+{
+    char output[128];
+    size_t length = capture_stream_output(stdout, output, sizeof(output), invoke_LOGD, NULL);
+    TEST_ASSERT_TRUE(length > 0);
+    TEST_ASSERT_EQUAL_STRING("[D] debug-tag: value=7 text=alpha\n", output);
+}
+
+void test_LOGI_formats_message(void)
+{
+    char output[128];
+    size_t length = capture_stream_output(stdout, output, sizeof(output), invoke_LOGI, NULL);
+    TEST_ASSERT_TRUE(length > 0);
+    TEST_ASSERT_EQUAL_STRING("[I] info-tag: value=42 text=beta\n", output);
+}
+
+void test_LOGW_formats_message(void)
+{
+    char output[128];
+    size_t length = capture_stream_output(stderr, output, sizeof(output), invoke_LOGW, NULL);
+    TEST_ASSERT_TRUE(length > 0);
+    TEST_ASSERT_EQUAL_STRING("[W] warn-tag: value=-1 text=gamma\n", output);
+}
+
+void test_LOGE_formats_message(void)
+{
+    char output[128];
+    size_t length = capture_stream_output(stderr, output, sizeof(output), invoke_LOGE, NULL);
+    TEST_ASSERT_TRUE(length > 0);
+    TEST_ASSERT_EQUAL_STRING("[E] error-tag: value=5 text=delta\n", output);
+}
+
+int main(int argc, char **argv)
+{
+    UnityConfigureFromArgs(argc, (const char **)argv);
+    UNITY_BEGIN();
+    RUN_TEST(test_LOGD_formats_message);
+    RUN_TEST(test_LOGI_formats_message);
+    RUN_TEST(test_LOGW_formats_message);
+    RUN_TEST(test_LOGE_formats_message);
+    return UNITY_END();
+}
+


### PR DESCRIPTION
## Summary
- rename the logs component wrapper functions to LOGD/LOGI/LOGW/LOGE as requested
- update host-side unit tests to exercise the renamed wrappers

## Testing
- cmake --build --preset host-tests
- ctest --preset host-tests

------
https://chatgpt.com/codex/tasks/task_e_68c9e2791168832e82795c1b5afdbc69