### PR TITLE
Add NVM initialization component and tests

### DIFF
--- a/esp32_mcu/components/nvm/CMakeLists.txt
+++ b/esp32_mcu/components/nvm/CMakeLists.txt
@@ -1,0 +1,7 @@
+idf_component_register(
+    SRCS nvm.c
+    INCLUDE_DIRS .
+    REQUIRES
+        log
+        nvs_flash
+)

--- a/esp32_mcu/components/nvm/nvm.c
+++ b/esp32_mcu/components/nvm/nvm.c
@@ -1,0 +1,66 @@
+#include "nvm.h"
+#include "nvm_partition.h"
+
+#include "esp_log.h"
+#include "nvs_flash.h"
+
+#include <stddef.h>
+
+static const char *TAG = "nvm";
+
+static esp_err_t ensure_partition_ready(const char *partition_label)
+{
+    if (!partition_label)
+        return ESP_ERR_INVALID_ARG;
+
+    esp_err_t err = nvs_flash_init_partition(partition_label);
+
+    if (err == ESP_ERR_NVS_NO_FREE_PAGES || err == ESP_ERR_NVS_NEW_VERSION_FOUND)
+    {
+        ESP_LOGW(TAG, "Erasing NVS partition %s due to previous error: %s", partition_label,
+                 esp_err_to_name(err));
+
+        err = nvs_flash_erase_partition(partition_label);
+        if (err != ESP_OK)
+        {
+            ESP_LOGE(TAG, "Failed to erase NVS partition %s: %s", partition_label,
+                     esp_err_to_name(err));
+            return err;
+        }
+
+        err = nvs_flash_init_partition(partition_label);
+    }
+
+    if (err != ESP_OK)
+    {
+        ESP_LOGE(TAG, "Failed to initialize NVS partition %s: %s", partition_label,
+                 esp_err_to_name(err));
+        return err;
+    }
+
+    ESP_LOGD(TAG, "NVS partition %s ready", partition_label);
+    return ESP_OK;
+}
+
+esp_err_t nvm_init_partition(const char *partition_label)
+{
+    return ensure_partition_ready(partition_label);
+}
+
+esp_err_t nvm_init(void)
+{
+    const char *partitions[] = {
+        NVM_PARTITION_DEFAULT,
+        NVM_PARTITION_CLIENTS,
+        NVM_PARTITION_NONCE,
+    };
+
+    for (size_t i = 0; i < sizeof(partitions) / sizeof(partitions[0]); ++i)
+    {
+        esp_err_t err = ensure_partition_ready(partitions[i]);
+        if (err != ESP_OK)
+            return err;
+    }
+
+    return ESP_OK;
+}

--- a/esp32_mcu/components/nvm/nvm.h
+++ b/esp32_mcu/components/nvm/nvm.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+esp_err_t nvm_init(void);
+esp_err_t nvm_init_partition(const char *partition_label);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/esp32_mcu/components/nvm/nvm_partition.h
+++ b/esp32_mcu/components/nvm/nvm_partition.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#define NVM_PARTITION_DEFAULT "nvs"
+#define NVM_PARTITION_CLIENTS "nvs_clients"
+#define NVM_PARTITION_NONCE   "nvs_nonce"
+

--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -58,12 +58,14 @@ target_include_directories(tapgate_production
         ${CMAKE_CURRENT_LIST_DIR}/../components/clients
         ${CMAKE_CURRENT_LIST_DIR}/../components/common
         ${CMAKE_CURRENT_LIST_DIR}/../components/logs
+        ${CMAKE_CURRENT_LIST_DIR}/../components/nvm
 )
 
 set(_tapgate_component_sources
     ${CMAKE_CURRENT_LIST_DIR}/../components/rsapem/rsapem.c
     ${CMAKE_CURRENT_LIST_DIR}/../components/clients/clients.c
     ${CMAKE_CURRENT_LIST_DIR}/../components/logs/logs.c
+    ${CMAKE_CURRENT_LIST_DIR}/../components/nvm/nvm.c
 )
 
 file(GLOB _tapgate_common_sources
@@ -147,4 +149,5 @@ tapgate_add_unity_test(test_types ${CMAKE_CURRENT_LIST_DIR}/test_types.c)
 tapgate_add_unity_test(test_clients ${CMAKE_CURRENT_LIST_DIR}/test_clients.c)
 tapgate_add_unity_test(test_rsapem ${CMAKE_CURRENT_LIST_DIR}/test_rsapem.c)
 tapgate_add_unity_test(test_logs ${CMAKE_CURRENT_LIST_DIR}/test_logs.c)
+tapgate_add_unity_test(test_nvm ${CMAKE_CURRENT_LIST_DIR}/test_nvm.c)
 

--- a/esp32_mcu/tests_host/mocks/include/nvs_flash.h
+++ b/esp32_mcu/tests_host/mocks/include/nvs_flash.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define ESP_ERR_NVS_BASE             0x1100
+#define ESP_ERR_NVS_NOT_INITIALIZED (ESP_ERR_NVS_BASE + 0x0)
+#define ESP_ERR_NVS_PART_NOT_FOUND  (ESP_ERR_NVS_BASE + 0x3)
+#define ESP_ERR_NVS_NEW_VERSION_FOUND (ESP_ERR_NVS_BASE + 0x10)
+#define ESP_ERR_NVS_NO_FREE_PAGES   (ESP_ERR_NVS_BASE + 0x11)
+
+esp_err_t nvs_flash_init_partition(const char *partition_name);
+esp_err_t nvs_flash_erase_partition(const char *partition_name);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/esp32_mcu/tests_host/test_nvm.c
+++ b/esp32_mcu/tests_host/test_nvm.c
@@ -1,0 +1,210 @@
+#include "unity.h"
+
+#include "nvm/nvm.h"
+#include "nvm/nvm_partition.h"
+#include "nvs_flash.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#define MAX_CALLS 8
+
+static const char *init_call_labels[MAX_CALLS];
+static size_t init_call_count;
+static esp_err_t init_results[MAX_CALLS];
+static size_t init_result_count;
+static size_t init_result_index;
+
+static const char *erase_call_labels[MAX_CALLS];
+static size_t erase_call_count;
+static esp_err_t erase_results[MAX_CALLS];
+static size_t erase_result_count;
+static size_t erase_result_index;
+
+static void reset_stubs(void)
+{
+    memset(init_call_labels, 0, sizeof(init_call_labels));
+    init_call_count = 0;
+    memset(init_results, 0, sizeof(init_results));
+    init_result_count = 0;
+    init_result_index = 0;
+
+    memset(erase_call_labels, 0, sizeof(erase_call_labels));
+    erase_call_count = 0;
+    memset(erase_results, 0, sizeof(erase_results));
+    erase_result_count = 0;
+    erase_result_index = 0;
+}
+
+static void set_init_results(const esp_err_t *values, size_t count)
+{
+    memset(init_results, 0, sizeof(init_results));
+    if (count > MAX_CALLS)
+        count = MAX_CALLS;
+    memcpy(init_results, values, count * sizeof(values[0]));
+    init_result_count = count;
+    init_result_index = 0;
+}
+
+static void set_erase_results(const esp_err_t *values, size_t count)
+{
+    memset(erase_results, 0, sizeof(erase_results));
+    if (count > MAX_CALLS)
+        count = MAX_CALLS;
+    memcpy(erase_results, values, count * sizeof(values[0]));
+    erase_result_count = count;
+    erase_result_index = 0;
+}
+
+esp_err_t nvs_flash_init_partition(const char *partition_name)
+{
+    if (init_call_count < MAX_CALLS)
+        init_call_labels[init_call_count] = partition_name;
+    init_call_count++;
+
+    if (init_result_index < init_result_count)
+        return init_results[init_result_index++];
+
+    return ESP_OK;
+}
+
+esp_err_t nvs_flash_erase_partition(const char *partition_name)
+{
+    if (erase_call_count < MAX_CALLS)
+        erase_call_labels[erase_call_count] = partition_name;
+    erase_call_count++;
+
+    if (erase_result_index < erase_result_count)
+        return erase_results[erase_result_index++];
+
+    return ESP_OK;
+}
+
+void setUp(void)
+{
+    reset_stubs();
+}
+
+void tearDown(void) {}
+
+void test_nvm_init_initializes_all_partitions(void)
+{
+    esp_err_t err = nvm_init();
+    TEST_ASSERT_EQUAL_INT(ESP_OK, err);
+    TEST_ASSERT_EQUAL_UINT32(3u, (uint32_t)init_call_count);
+    TEST_ASSERT_NOT_NULL(init_call_labels[0]);
+    TEST_ASSERT_NOT_NULL(init_call_labels[1]);
+    TEST_ASSERT_NOT_NULL(init_call_labels[2]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_DEFAULT, init_call_labels[0]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_CLIENTS, init_call_labels[1]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_NONCE, init_call_labels[2]);
+    TEST_ASSERT_EQUAL_UINT32(0u, (uint32_t)erase_call_count);
+}
+
+void test_nvm_init_handles_no_free_pages(void)
+{
+    const esp_err_t init_sequence[] = {
+        ESP_ERR_NVS_NO_FREE_PAGES,
+        ESP_OK,
+        ESP_OK,
+        ESP_OK,
+    };
+    const esp_err_t erase_sequence[] = {
+        ESP_OK,
+    };
+
+    set_init_results(init_sequence, sizeof(init_sequence) / sizeof(init_sequence[0]));
+    set_erase_results(erase_sequence, sizeof(erase_sequence) / sizeof(erase_sequence[0]));
+
+    esp_err_t err = nvm_init();
+    TEST_ASSERT_EQUAL_INT(ESP_OK, err);
+    TEST_ASSERT_EQUAL_UINT32(4u, (uint32_t)init_call_count);
+    TEST_ASSERT_NOT_NULL(init_call_labels[0]);
+    TEST_ASSERT_NOT_NULL(init_call_labels[1]);
+    TEST_ASSERT_NOT_NULL(init_call_labels[2]);
+    TEST_ASSERT_NOT_NULL(init_call_labels[3]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_DEFAULT, init_call_labels[0]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_DEFAULT, init_call_labels[1]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_CLIENTS, init_call_labels[2]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_NONCE, init_call_labels[3]);
+    TEST_ASSERT_EQUAL_UINT32(1u, (uint32_t)erase_call_count);
+    TEST_ASSERT_NOT_NULL(erase_call_labels[0]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_DEFAULT, erase_call_labels[0]);
+}
+
+void test_nvm_init_stops_when_erase_fails(void)
+{
+    const esp_err_t init_sequence[] = {
+        ESP_ERR_NVS_NO_FREE_PAGES,
+    };
+    const esp_err_t erase_sequence[] = {
+        ESP_FAIL,
+    };
+
+    set_init_results(init_sequence, sizeof(init_sequence) / sizeof(init_sequence[0]));
+    set_erase_results(erase_sequence, sizeof(erase_sequence) / sizeof(erase_sequence[0]));
+
+    esp_err_t err = nvm_init();
+    TEST_ASSERT_EQUAL_INT(ESP_FAIL, err);
+    TEST_ASSERT_EQUAL_UINT32(1u, (uint32_t)init_call_count);
+    TEST_ASSERT_EQUAL_UINT32(1u, (uint32_t)erase_call_count);
+    TEST_ASSERT_NOT_NULL(erase_call_labels[0]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_DEFAULT, erase_call_labels[0]);
+}
+
+void test_nvm_init_propagates_init_error(void)
+{
+    const esp_err_t init_sequence[] = {
+        ESP_ERR_NOT_FOUND,
+    };
+
+    set_init_results(init_sequence, sizeof(init_sequence) / sizeof(init_sequence[0]));
+
+    esp_err_t err = nvm_init();
+    TEST_ASSERT_EQUAL_INT(ESP_ERR_NOT_FOUND, err);
+    TEST_ASSERT_EQUAL_UINT32(1u, (uint32_t)init_call_count);
+    TEST_ASSERT_EQUAL_UINT32(0u, (uint32_t)erase_call_count);
+}
+
+void test_nvm_init_handles_new_version_found(void)
+{
+    const esp_err_t init_sequence[] = {
+        ESP_ERR_NVS_NEW_VERSION_FOUND,
+        ESP_OK,
+        ESP_OK,
+        ESP_OK,
+    };
+    const esp_err_t erase_sequence[] = {
+        ESP_OK,
+    };
+
+    set_init_results(init_sequence, sizeof(init_sequence) / sizeof(init_sequence[0]));
+    set_erase_results(erase_sequence, sizeof(erase_sequence) / sizeof(erase_sequence[0]));
+
+    esp_err_t err = nvm_init();
+    TEST_ASSERT_EQUAL_INT(ESP_OK, err);
+    TEST_ASSERT_EQUAL_UINT32(4u, (uint32_t)init_call_count);
+    TEST_ASSERT_NOT_NULL(init_call_labels[0]);
+    TEST_ASSERT_NOT_NULL(init_call_labels[1]);
+    TEST_ASSERT_NOT_NULL(init_call_labels[2]);
+    TEST_ASSERT_NOT_NULL(init_call_labels[3]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_DEFAULT, init_call_labels[0]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_DEFAULT, init_call_labels[1]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_CLIENTS, init_call_labels[2]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_NONCE, init_call_labels[3]);
+    TEST_ASSERT_EQUAL_UINT32(1u, (uint32_t)erase_call_count);
+    TEST_ASSERT_NOT_NULL(erase_call_labels[0]);
+    TEST_ASSERT_EQUAL_STRING(NVM_PARTITION_DEFAULT, erase_call_labels[0]);
+}
+
+int main(int argc, char **argv)
+{
+    UnityConfigureFromArgs(argc, (const char **)argv);
+    UNITY_BEGIN();
+    RUN_TEST(test_nvm_init_initializes_all_partitions);
+    RUN_TEST(test_nvm_init_handles_no_free_pages);
+    RUN_TEST(test_nvm_init_stops_when_erase_fails);
+    RUN_TEST(test_nvm_init_propagates_init_error);
+    RUN_TEST(test_nvm_init_handles_new_version_found);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- add an nvm component that prepares the configured NVS partitions without wiping existing data
- provide partition name constants and host-side nvs_flash stubs used by the component
- cover the initialization flows with a dedicated Unity host unit test

## Testing
- cmake -S esp32_mcu/tests_host -B esp32_mcu/tests_host/build
- cmake --build esp32_mcu/tests_host/build
- ctest --test-dir esp32_mcu/tests_host/build


------
https://chatgpt.com/codex/tasks/task_e_68cc687bb174832ea0b6ba5003906288