### PR TITLE
Refine RSA PEM API for cleaner usage

### DIFF
--- a/esp32_mcu/components/rsapem/CMakeLists.txt
+++ b/esp32_mcu/components/rsapem/CMakeLists.txt
@@ -5,5 +5,6 @@ file(GLOB srcs
 idf_component_register(
     SRCS ${srcs}
     INCLUDE_DIRS .
-    REQUIRES common
+    REQUIRES common mbedtls log
 )
+

--- a/esp32_mcu/components/rsapem/rsapem.c
+++ b/esp32_mcu/components/rsapem/rsapem.c
@@ -1,1 +1,241 @@
 #include "rsapem.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_log.h"
+
+#ifdef ESP_PLATFORM
+#include "mbedtls/ctr_drbg.h"
+#include "mbedtls/entropy.h"
+#include "mbedtls/pk.h"
+#include "mbedtls/rsa.h"
+#endif
+
+#define RSAPEM_LOG_TAG "rsapem"
+#define RSAPEM_RSA_PUBLIC_EXPONENT 65537
+
+static size_t rsapem_bytes_for_bits(int key_bits)
+{
+    if (key_bits <= 0)
+    {
+        return 0;
+    }
+    return (size_t)((key_bits + 7) / 8);
+}
+
+static size_t rsapem_public_capacity(int key_bits)
+{
+    size_t modulus_bytes = rsapem_bytes_for_bits(key_bits);
+    if (modulus_bytes == 0)
+    {
+        return 0;
+    }
+
+    size_t der_bytes = modulus_bytes + 64;
+    size_t base64_bytes = ((der_bytes + 2) / 3) * 4;
+    size_t newline_bytes = (base64_bytes / 64) + 1;
+    return base64_bytes + newline_bytes + 64 + 1;
+}
+
+static size_t rsapem_private_capacity(int key_bits)
+{
+    size_t modulus_bytes = rsapem_bytes_for_bits(key_bits);
+    if (modulus_bytes == 0)
+    {
+        return 0;
+    }
+
+    size_t der_bytes = ((modulus_bytes * 9) + 1) / 2 + 64;
+    size_t base64_bytes = ((der_bytes + 2) / 3) * 4;
+    size_t newline_bytes = (base64_bytes / 64) + 1;
+    return base64_bytes + newline_bytes + 64 + 1;
+}
+
+static void rsapem_secure_zero(void *buffer, size_t length)
+{
+    if (!buffer || length == 0)
+    {
+        return;
+    }
+
+    volatile unsigned char *ptr = (volatile unsigned char *)buffer;
+    while (length--)
+    {
+        *ptr++ = 0;
+    }
+}
+
+static void rsapem_reset_keypair(rsapem_keypair_t *keypair)
+{
+    if (!keypair)
+    {
+        return;
+    }
+
+    keypair->public_pem = NULL;
+    keypair->public_pem_length = 0;
+    keypair->private_pem = NULL;
+    keypair->private_pem_length = 0;
+}
+
+esp_err_t rsapem_generate_keypair(int key_bits, rsapem_keypair_t *keypair)
+{
+    if (!keypair)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    rsapem_reset_keypair(keypair);
+
+    if (key_bits < RSAPEM_MIN_KEY_BITS || key_bits > RSAPEM_MAX_KEY_BITS)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    size_t public_capacity = rsapem_public_capacity(key_bits);
+    size_t private_capacity = rsapem_private_capacity(key_bits);
+    if (public_capacity == 0 || private_capacity == 0)
+    {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    char *public_buffer = (char *)calloc(public_capacity, sizeof(char));
+    char *private_buffer = (char *)calloc(private_capacity, sizeof(char));
+    if (!public_buffer || !private_buffer)
+    {
+        free(public_buffer);
+        rsapem_secure_zero(private_buffer, private_capacity);
+        free(private_buffer);
+        return ESP_ERR_NO_MEM;
+    }
+
+#ifdef ESP_PLATFORM
+    esp_err_t status = ESP_OK;
+    bool success = true;
+    int ret = 0;
+
+    mbedtls_pk_context pk;
+    mbedtls_ctr_drbg_context ctr_drbg;
+    mbedtls_entropy_context entropy;
+
+    mbedtls_pk_init(&pk);
+    mbedtls_ctr_drbg_init(&ctr_drbg);
+    mbedtls_entropy_init(&entropy);
+
+    const mbedtls_pk_info_t *pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_RSA);
+    if (!pk_info)
+    {
+        ESP_LOGE(RSAPEM_LOG_TAG, "Failed to resolve RSA pk info");
+        status = ESP_FAIL;
+        success = false;
+    }
+    else if ((ret = mbedtls_pk_setup(&pk, pk_info)) != 0)
+    {
+        ESP_LOGE(RSAPEM_LOG_TAG, "mbedtls_pk_setup failed (%d)", ret);
+        status = ESP_FAIL;
+        success = false;
+    }
+
+    const unsigned char personalization[] = "rsapem";
+    if (success)
+    {
+        ret = mbedtls_ctr_drbg_seed(&ctr_drbg, mbedtls_entropy_func, &entropy,
+                                    personalization, sizeof(personalization));
+        if (ret != 0)
+        {
+            ESP_LOGE(RSAPEM_LOG_TAG, "mbedtls_ctr_drbg_seed failed (%d)", ret);
+            status = ESP_FAIL;
+            success = false;
+        }
+    }
+
+    if (success)
+    {
+        ret = mbedtls_rsa_gen_key(mbedtls_pk_rsa(pk), mbedtls_ctr_drbg_random, &ctr_drbg,
+                                  key_bits, RSAPEM_RSA_PUBLIC_EXPONENT);
+        if (ret != 0)
+        {
+            ESP_LOGE(RSAPEM_LOG_TAG, "mbedtls_rsa_gen_key failed (%d)", ret);
+            status = ESP_FAIL;
+            success = false;
+        }
+    }
+
+    if (success)
+    {
+        ret = mbedtls_pk_write_pubkey_pem(&pk, (unsigned char *)public_buffer, public_capacity);
+        if (ret != 0)
+        {
+            ESP_LOGE(RSAPEM_LOG_TAG, "Failed to export public key (%d)", ret);
+            status = ESP_FAIL;
+            success = false;
+        }
+    }
+
+    if (success)
+    {
+        ret = mbedtls_pk_write_key_pem(&pk, (unsigned char *)private_buffer, private_capacity);
+        if (ret != 0)
+        {
+            ESP_LOGE(RSAPEM_LOG_TAG, "Failed to export private key (%d)", ret);
+            status = ESP_FAIL;
+            success = false;
+        }
+    }
+
+    if (success)
+    {
+        keypair->public_pem = public_buffer;
+        keypair->public_pem_length = strlen(public_buffer);
+        keypair->private_pem = private_buffer;
+        keypair->private_pem_length = strlen(private_buffer);
+    }
+    else
+    {
+        rsapem_secure_zero(private_buffer, private_capacity);
+        free(public_buffer);
+        free(private_buffer);
+    }
+
+    mbedtls_pk_free(&pk);
+    mbedtls_ctr_drbg_free(&ctr_drbg);
+    mbedtls_entropy_free(&entropy);
+
+    if (success)
+    {
+        return ESP_OK;
+    }
+
+    return status;
+#else
+    (void)key_bits;
+    rsapem_secure_zero(private_buffer, private_capacity);
+    free(public_buffer);
+    free(private_buffer);
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
+void rsapem_free_keypair(rsapem_keypair_t *keypair)
+{
+    if (!keypair)
+    {
+        return;
+    }
+
+    if (keypair->public_pem)
+    {
+        free(keypair->public_pem);
+    }
+
+    if (keypair->private_pem)
+    {
+        rsapem_secure_zero(keypair->private_pem, keypair->private_pem_length + 1);
+        free(keypair->private_pem);
+    }
+
+    rsapem_reset_keypair(keypair);
+}
+

--- a/esp32_mcu/components/rsapem/rsapem.h
+++ b/esp32_mcu/components/rsapem/rsapem.h
@@ -1,5 +1,26 @@
 #pragma once
 
-// include components
-#include "types.h"
-#include "constants.h"
+#include <stddef.h>
+
+#include "esp_err.h"
+
+#ifndef ESP_ERR_NOT_SUPPORTED
+#define ESP_ERR_NOT_SUPPORTED 0x106
+#endif
+
+#define RSAPEM_DEFAULT_KEY_BITS 2048
+#define RSAPEM_MIN_KEY_BITS     1024
+#define RSAPEM_MAX_KEY_BITS     4096
+
+typedef struct
+{
+    char *public_pem;
+    size_t public_pem_length; /* Excluding the terminating null byte. */
+    char *private_pem;
+    size_t private_pem_length; /* Excluding the terminating null byte. */
+} rsapem_keypair_t;
+
+esp_err_t rsapem_generate_keypair(int key_bits, rsapem_keypair_t *keypair);
+
+void rsapem_free_keypair(rsapem_keypair_t *keypair);
+

--- a/esp32_mcu/tests_host/test_rsapem.c
+++ b/esp32_mcu/tests_host/test_rsapem.c
@@ -1,14 +1,62 @@
 #include "unity.h"
-#include "clients/clients.h"
+#include "rsapem/rsapem.h"
+
+#include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 void setUp(void) {}
 void tearDown(void) {}
 
+void test_rsapem_rejects_null_keypair(void)
+{
+    TEST_ASSERT_EQUAL_INT(ESP_ERR_INVALID_ARG,
+                          rsapem_generate_keypair(RSAPEM_DEFAULT_KEY_BITS, NULL));
+}
+
+void test_rsapem_rejects_invalid_key_size(void)
+{
+    rsapem_keypair_t keypair;
+    TEST_ASSERT_EQUAL_INT(ESP_ERR_INVALID_ARG,
+                          rsapem_generate_keypair(RSAPEM_MIN_KEY_BITS - 1, &keypair));
+    TEST_ASSERT_EQUAL_INT(ESP_ERR_INVALID_ARG,
+                          rsapem_generate_keypair(RSAPEM_MAX_KEY_BITS + 1, &keypair));
+}
+
+void test_rsapem_not_supported_on_host(void)
+{
+    rsapem_keypair_t keypair;
+    TEST_ASSERT_EQUAL_INT(ESP_ERR_NOT_SUPPORTED,
+                          rsapem_generate_keypair(RSAPEM_DEFAULT_KEY_BITS, &keypair));
+    TEST_ASSERT_NULL(keypair.public_pem);
+    TEST_ASSERT_NULL(keypair.private_pem);
+    rsapem_free_keypair(&keypair);
+}
+
+void test_rsapem_free_handles_null(void)
+{
+    rsapem_free_keypair(NULL);
+
+    rsapem_keypair_t keypair;
+    keypair.public_pem = NULL;
+    keypair.private_pem = NULL;
+    keypair.public_pem_length = 123;
+    keypair.private_pem_length = 456;
+    rsapem_free_keypair(&keypair);
+    TEST_ASSERT_NULL(keypair.public_pem);
+    TEST_ASSERT_NULL(keypair.private_pem);
+    TEST_ASSERT_EQUAL_UINT32(0, (uint32_t)keypair.public_pem_length);
+    TEST_ASSERT_EQUAL_UINT32(0, (uint32_t)keypair.private_pem_length);
+}
+
 int main(int argc, char **argv)
 {
     UnityConfigureFromArgs(argc, (const char **)argv);
     UNITY_BEGIN();
-    //RUN_TEST(test_name);
+    RUN_TEST(test_rsapem_rejects_null_keypair);
+    RUN_TEST(test_rsapem_rejects_invalid_key_size);
+    RUN_TEST(test_rsapem_not_supported_on_host);
+    RUN_TEST(test_rsapem_free_handles_null);
     return UNITY_END();
 }
+


### PR DESCRIPTION
## Summary
- simplify the RSA PEM component to expose a single keypair-generating API with a matching cleanup helper
- refactor the implementation to allocate its own buffers, avoid goto-based flow, and keep secure zeroing internal
- update the host-side unit tests to match the streamlined interface and behaviour

## Testing
- cmake --preset host-tests
- cmake --build --preset host-tests
- ctest --preset host-tests

------
https://chatgpt.com/codex/tasks/task_e_68cc69a606c0832e8c7025bb254c190b