### PR TITLE
Implement admin portal HTTP service

### DIFF
--- a/esp32_mcu/components/admin_portal/CMakeLists.txt
+++ b/esp32_mcu/components/admin_portal/CMakeLists.txt
@@ -1,5 +1,7 @@
 # Collect all C sources in this component
 file(GLOB srcs "${CMAKE_CURRENT_LIST_DIR}/*.c")
+file(GLOB page_srcs "${CMAKE_CURRENT_LIST_DIR}/pages/*.c")
+list(APPEND srcs ${page_srcs})
 
 # Path to web folder
 set(WEB_DIR ${CMAKE_CURRENT_SOURCE_DIR}/assets)

--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -1,0 +1,235 @@
+#include "http_service.h"
+
+#include <ctype.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "esp_err.h"
+
+#include "http_service_facade.h"
+#include "logs.h"
+#include "page_ap.h"
+#include "page_main.h"
+#include "wifi_manager.h"
+
+static const char *TAG = "HTTP Service";
+
+static const char *URI_ROOT = "/";
+static const char *URI_MAIN = "/api/v1/main";
+static const char *URI_AP = "/api/v1/ap";
+static const char *URI_LOGO = "/assets/logo.png";
+
+extern const uint8_t _binary_assets_logo_png_start[] asm("_binary_assets_logo_png_start");
+extern const uint8_t _binary_assets_logo_png_end[] asm("_binary_assets_logo_png_end");
+
+static bool string_is_blank(const char *text)
+{
+    if (!text) {
+        return true;
+    }
+    while (*text) {
+        if (!isspace((unsigned char)*text)) {
+            return false;
+        }
+        ++text;
+    }
+    return true;
+}
+
+esp_err_t http_service_init(void)
+{
+    return ESP_OK;
+}
+
+void http_service_deinit(void)
+{
+}
+
+static esp_err_t redirect(httpd_req_t *req, const char *location)
+{
+    httpd_resp_set_status(req, "302 Found");
+    httpd_resp_set_hdr(req, "Location", location);
+    return httpd_resp_send(req, NULL, 0);
+}
+
+static void url_decode_inplace(char *str)
+{
+    char *src = str;
+    char *dst = str;
+    while (*src) {
+        if (*src == '+') {
+            *dst++ = ' ';
+            ++src;
+        } else if (*src == '%' && isxdigit((unsigned char)src[1]) && isxdigit((unsigned char)src[2])) {
+            char hex[3] = { src[1], src[2], '\0' };
+            *dst++ = (char)strtol(hex, NULL, 16);
+            src += 3;
+        } else {
+            *dst++ = *src++;
+        }
+    }
+    *dst = '\0';
+}
+
+static bool parse_form_body(char *body, char *ssid, size_t ssid_len, char *password, size_t password_len)
+{
+    bool has_ssid = false;
+    bool has_password = false;
+
+    char *saveptr = NULL;
+    for (char *pair = strtok_r(body, "&", &saveptr); pair; pair = strtok_r(NULL, "&", &saveptr)) {
+        char *value = strchr(pair, '=');
+        if (!value) {
+            continue;
+        }
+
+        *value = '\0';
+        ++value;
+        url_decode_inplace(pair);
+        url_decode_inplace(value);
+
+        if (strcmp(pair, "ssid") == 0) {
+            strlcpy(ssid, value, ssid_len);
+            has_ssid = true;
+        } else if (strcmp(pair, "password") == 0) {
+            strlcpy(password, value, password_len);
+            has_password = true;
+        }
+    }
+
+    return has_ssid && has_password;
+}
+
+static esp_err_t send_logo(httpd_req_t *req)
+{
+    const uint8_t *start = _binary_assets_logo_png_start;
+    const uint8_t *end = _binary_assets_logo_png_end;
+    httpd_resp_set_type(req, "image/png");
+    return httpd_resp_send(req, (const char *)start, end - start);
+}
+
+static esp_err_t render_ap_page(httpd_req_t *req, const char *status, bool is_error,
+                                const char *ssid, const char *password,
+                                bool highlight_ssid, bool highlight_password)
+{
+    page_ap_context_t context = {
+        .ssid = ssid,
+        .password = password,
+        .status_message = status,
+        .status_is_error = is_error,
+        .show_cancel = http_service_facade_has_valid_ap_password(),
+        .highlight_ssid = highlight_ssid,
+        .highlight_password = highlight_password,
+    };
+    return page_ap_render(req, &context);
+}
+
+static esp_err_t handle_get_ap(httpd_req_t *req)
+{
+    char ssid[MAX_SSID_SIZE] = {0};
+    char password[MAX_PASSWORD_SIZE] = {0};
+
+    esp_err_t err = http_service_facade_get_ap_credentials(ssid, sizeof(ssid), password, sizeof(password));
+    if (err != ESP_OK) {
+        LOGW(TAG, "Failed to load AP credentials (%s)", esp_err_to_name(err));
+    }
+
+    return render_ap_page(req, "", false, ssid, password, false, false);
+}
+
+static esp_err_t handle_get_main(httpd_req_t *req)
+{
+    page_main_context_t context = {
+        .version_label = "TapGate ver: 1",
+    };
+    return page_main_render(req, &context);
+}
+
+esp_err_t http_service_handle_get(httpd_req_t *req)
+{
+    const char *uri = req->uri;
+    LOGI(TAG, "GET %s", uri);
+
+    if (strcmp(uri, URI_ROOT) == 0 || strcmp(uri, "/index.html") == 0) {
+        const char *target = http_service_facade_has_valid_ap_password() ? URI_MAIN : URI_AP;
+        return redirect(req, target);
+    }
+
+    if (strcmp(uri, URI_MAIN) == 0) {
+        return handle_get_main(req);
+    }
+
+    if (strcmp(uri, URI_AP) == 0) {
+        return handle_get_ap(req);
+    }
+
+    if (strcmp(uri, URI_LOGO) == 0) {
+        return send_logo(req);
+    }
+
+    return httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Not found");
+}
+
+static esp_err_t handle_ap_post(httpd_req_t *req)
+{
+    if (req->content_len == 0 || req->content_len >= 512) {
+        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "Invalid payload");
+    }
+
+    char body[512] = {0};
+    size_t received = 0;
+    while (received < req->content_len) {
+        int ret = httpd_req_recv(req, body + received, req->content_len - received);
+        if (ret <= 0) {
+            return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to read request");
+        }
+        received += ret;
+    }
+    body[received] = '\0';
+
+    char ssid[MAX_SSID_SIZE] = {0};
+    char password[MAX_PASSWORD_SIZE] = {0};
+    if (!parse_form_body(body, ssid, sizeof(ssid), password, sizeof(password))) {
+        return render_ap_page(req, "Invalid form data", true, ssid, password, true, true);
+    }
+
+    if (string_is_blank(ssid)) {
+        return render_ap_page(req, "SSID is required", true, ssid, password, true, false);
+    }
+
+    if (strlen(password) < WPA2_MINIMUM_PASSWORD_LENGTH) {
+        return render_ap_page(req, "Password must be at least 8 characters", true, ssid, password, false, true);
+    }
+
+    esp_err_t err = http_service_facade_store_ap_credentials(ssid, password);
+    if (err != ESP_OK) {
+        LOGE(TAG, "Failed to save AP credentials (%s)", esp_err_to_name(err));
+        const char *message = (err == ESP_ERR_INVALID_SIZE)
+            ? "Values exceed allowed length"
+            : "Failed to save credentials";
+        bool highlight = (err == ESP_ERR_INVALID_SIZE);
+        return render_ap_page(req, message, true, ssid, password, highlight, highlight);
+    }
+
+    return redirect(req, URI_MAIN);
+}
+
+esp_err_t http_service_handle_post(httpd_req_t *req)
+{
+    const char *uri = req->uri;
+    LOGI(TAG, "POST %s", uri);
+
+    if (strcmp(uri, URI_AP) == 0) {
+        return handle_ap_post(req);
+    }
+
+    return httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Not found");
+}
+
+esp_err_t http_service_handle_delete(httpd_req_t *req)
+{
+    LOGI(TAG, "DELETE %s", req->uri);
+    return httpd_resp_send_err(req, HTTPD_405_METHOD_NOT_ALLOWED, "Unsupported method");
+}
+

--- a/esp32_mcu/components/admin_portal/http_service.h
+++ b/esp32_mcu/components/admin_portal/http_service.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "esp_err.h"
+#include "esp_http_server.h"
+
+// Initialize any state required by the HTTP service.
+esp_err_t http_service_init(void);
+
+// Release resources allocated by the HTTP service.
+void http_service_deinit(void);
+
+// Handle HTTP GET requests routed by the server.
+esp_err_t http_service_handle_get(httpd_req_t *req);
+
+// Handle HTTP POST requests routed by the server.
+esp_err_t http_service_handle_post(httpd_req_t *req);
+
+// Handle HTTP DELETE requests routed by the server.
+esp_err_t http_service_handle_delete(httpd_req_t *req);

--- a/esp32_mcu/components/admin_portal/http_service_facade.c
+++ b/esp32_mcu/components/admin_portal/http_service_facade.c
@@ -1,0 +1,129 @@
+#include "http_service_facade.h"
+
+#include <ctype.h>
+#include <string.h>
+
+#include "esp_err.h"
+#include "esp_wifi.h"
+#include "nvs.h"
+
+#include "logs.h"
+#include "wifi_manager.h"
+
+static const char *TAG = "HTTP Service Facade";
+
+static esp_err_t save_wifi_settings_to_nvm(void)
+{
+    nvs_handle handle;
+    esp_err_t err = nvs_open_from_partition(NVM_WIFI_PARTITION, NVM_WIFI_NAMESPACE, NVS_READWRITE, &handle);
+    if (err != ESP_OK) {
+        LOGE(TAG, "Failed to open NVM %s:%s (%s)", NVM_WIFI_PARTITION, NVM_WIFI_NAMESPACE, esp_err_to_name(err));
+        return err;
+    }
+
+    err = nvs_set_blob(handle, STORE_NVM_SETTINGS, &wifi_settings, sizeof(wifi_settings));
+    if (err == ESP_OK) {
+        err = nvs_commit(handle);
+    }
+
+    if (err != ESP_OK) {
+        LOGE(TAG, "Failed to store AP settings (%s)", esp_err_to_name(err));
+    } else {
+        LOGI(TAG, "Stored AP settings: ssid=%s", wifi_settings.ap_ssid);
+    }
+
+    nvs_close(handle);
+    return err;
+}
+
+static bool string_is_blank(const char *text)
+{
+    if (!text) {
+        return true;
+    }
+
+    while (*text) {
+        if (!isspace((unsigned char)*text)) {
+            return false;
+        }
+        ++text;
+    }
+    return true;
+}
+
+esp_err_t http_service_facade_get_ap_credentials(char *ssid, size_t ssid_len,
+                                                 char *password, size_t password_len)
+{
+    if (!ssid || !password || ssid_len == 0 || password_len == 0) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    strlcpy(ssid, (const char *)wifi_settings.ap_ssid, ssid_len);
+    strlcpy(password, (const char *)wifi_settings.ap_pwd, password_len);
+    return ESP_OK;
+}
+
+bool http_service_facade_has_valid_ap_password(void)
+{
+    size_t length = strlen((const char *)wifi_settings.ap_pwd);
+    return length >= WPA2_MINIMUM_PASSWORD_LENGTH;
+}
+
+esp_err_t http_service_facade_store_ap_credentials(const char *ssid, const char *password)
+{
+    if (!ssid || !password) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    size_t ssid_len = strlen(ssid);
+    size_t password_len = strlen(password);
+
+    if (string_is_blank(ssid) || ssid_len == 0 || ssid_len >= sizeof(wifi_settings.ap_ssid)) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    if (password_len < WPA2_MINIMUM_PASSWORD_LENGTH || password_len >= sizeof(wifi_settings.ap_pwd)) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    wifi_config_t ap_config = { 0 };
+    ap_config.ap.channel = wifi_settings.ap_channel;
+    ap_config.ap.ssid_hidden = wifi_settings.ap_ssid_hidden;
+    ap_config.ap.max_connection = DEFAULT_AP_MAX_CONNECTIONS;
+    ap_config.ap.beacon_interval = DEFAULT_AP_BEACON_INTERVAL;
+    ap_config.ap.authmode = WIFI_AUTH_WPA2_PSK;
+    ap_config.ap.ssid_len = 0;
+    strlcpy((char *)ap_config.ap.ssid, ssid, sizeof(ap_config.ap.ssid));
+    strlcpy((char *)ap_config.ap.password, password, sizeof(ap_config.ap.password));
+
+    esp_err_t err = esp_wifi_set_config(WIFI_IF_AP, &ap_config);
+    if (err == ESP_ERR_WIFI_NOT_INIT || err == ESP_ERR_WIFI_NOT_STARTED) {
+        LOGW(TAG, "WiFi not ready, storing credentials only (%s)", esp_err_to_name(err));
+        err = ESP_OK;
+    } else if (err != ESP_OK) {
+        LOGE(TAG, "Failed to apply AP config (%s)", esp_err_to_name(err));
+        return err;
+    }
+
+    esp_err_t bw_err = esp_wifi_set_bandwidth(WIFI_IF_AP, wifi_settings.ap_bandwidth);
+    if (bw_err == ESP_ERR_WIFI_NOT_INIT || bw_err == ESP_ERR_WIFI_NOT_STARTED) {
+        LOGW(TAG, "WiFi not ready to apply bandwidth (%s)", esp_err_to_name(bw_err));
+    } else if (bw_err != ESP_OK) {
+        LOGE(TAG, "Failed to apply AP bandwidth (%s)", esp_err_to_name(bw_err));
+        return bw_err;
+    }
+
+    memset(wifi_settings.ap_ssid, 0, sizeof(wifi_settings.ap_ssid));
+    memset(wifi_settings.ap_pwd, 0, sizeof(wifi_settings.ap_pwd));
+    strlcpy((char *)wifi_settings.ap_ssid, ssid, sizeof(wifi_settings.ap_ssid));
+    strlcpy((char *)wifi_settings.ap_pwd, password, sizeof(wifi_settings.ap_pwd));
+
+    err = save_wifi_settings_to_nvm();
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    LOGI(TAG, "Updated AP credentials");
+    return ESP_OK;
+}
+

--- a/esp32_mcu/components/admin_portal/http_service_facade.h
+++ b/esp32_mcu/components/admin_portal/http_service_facade.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <stdbool.h>
+#include <stddef.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Retrieve the stored Access Point credentials.
+esp_err_t http_service_facade_get_ap_credentials(char *ssid, size_t ssid_len,
+                                                 char *password, size_t password_len);
+
+// Persist new Access Point credentials. Performs validation internally.
+esp_err_t http_service_facade_store_ap_credentials(const char *ssid, const char *password);
+
+// Returns true when a valid Access Point password is stored.
+bool http_service_facade_has_valid_ap_password(void);
+
+#ifdef __cplusplus
+}
+#endif
+

--- a/esp32_mcu/components/admin_portal/pages/page_ap.c
+++ b/esp32_mcu/components/admin_portal/pages/page_ap.c
@@ -1,0 +1,178 @@
+#include "page_ap.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static void html_escape(const char *input, char *output, size_t output_len)
+{
+    if (!input || !output || output_len == 0) {
+        return;
+    }
+
+    size_t out_idx = 0;
+    for (size_t i = 0; input[i] != '\0' && out_idx + 1 < output_len; ++i) {
+        char c = input[i];
+        const char *entity = NULL;
+        switch (c) {
+            case '&': entity = "&amp;"; break;
+            case '<': entity = "&lt;"; break;
+            case '>': entity = "&gt;"; break;
+            case '"': entity = "&quot;"; break;
+            case '\'': entity = "&#39;"; break;
+            default: break;
+        }
+
+        if (entity) {
+            size_t entity_len = strlen(entity);
+            if (out_idx + entity_len < output_len) {
+                memcpy(&output[out_idx], entity, entity_len);
+                out_idx += entity_len;
+            } else {
+                break;
+            }
+        } else {
+            output[out_idx++] = c;
+        }
+    }
+    output[out_idx] = '\0';
+}
+
+esp_err_t page_ap_render(httpd_req_t *req, const page_ap_context_t *context)
+{
+    if (!req || !context) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    char ssid_escaped[96];
+    char password_escaped[96];
+    char status_escaped[160];
+
+    html_escape(context->ssid ? context->ssid : "", ssid_escaped, sizeof(ssid_escaped));
+    html_escape(context->password ? context->password : "", password_escaped, sizeof(password_escaped));
+    html_escape(context->status_message ? context->status_message : "", status_escaped, sizeof(status_escaped));
+
+    httpd_resp_set_type(req, "text/html; charset=utf-8");
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate");
+
+    const char *status_class = context->status_is_error ? "status error" : "status";
+    const char *ssid_field_class = context->highlight_ssid ? "field error" : "field";
+    const char *password_field_class = context->highlight_password ? "field error" : "field";
+
+    const char *cancel_visibility = context->show_cancel ? "flex" : "none";
+
+    const char *head =
+        "<!DOCTYPE html>"
+        "<html lang=\"en\">"
+        "<head>"
+            "<meta charset=\"UTF-8\">"
+            "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+            "<title>TapGate AP Setup</title>"
+            "<style>"
+                "*{box-sizing:border-box;font-family:'Inter','Segoe UI',sans-serif;}"
+                ":root{--bg:#0D1520;--card:#111927;--accent:#3B82F6;--text:#E6EEF8;--muted:#9CA3AF;"
+                "--input-border:#2A3642;--error:#F87171;--button-height:48px;}"
+                "body{margin:0;background:var(--bg);color:var(--text);min-height:100vh;}"
+                ".page{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:24px;}"
+                ".card{width:100%;max-width:420px;background:var(--card);border-radius:20px;"
+                "padding:28px 24px;box-shadow:0 20px 45px rgba(8,12,24,0.45);}"
+                ".card h1{margin:0 0 24px;font-size:24px;font-weight:600;text-align:center;}"
+                ".field{display:flex;flex-direction:column;margin-bottom:20px;}"
+                ".field label{font-size:14px;color:var(--muted);margin-bottom:6px;font-weight:500;transition:color .2s;}"
+                ".field input{height:var(--button-height);padding:0 16px;border-radius:12px;border:1px solid var(--input-border);"
+                "background:linear-gradient(180deg,#10161D 0%,#0C1117 100%);color:var(--text);font-size:16px;"
+                "transition:border .2s,box-shadow .2s;}"
+                ".field input::placeholder{color:rgba(122,138,159,0.7);}"
+                ".field:focus-within label{color:var(--accent);}"
+                ".field input:focus{outline:none;border-color:var(--accent);box-shadow:0 0 0 3px rgba(59,130,246,0.35);}"
+                ".field.error label{color:var(--error);}"
+                ".field.error input{border-color:var(--error);}"
+                ".actions{display:flex;flex-direction:column;gap:14px;margin-top:10px;}"
+                ".button{height:var(--button-height);border:none;border-radius:14px;"
+                "background:linear-gradient(135deg,#0b2451 0%,#1c4c8c 45%,#3a8fdd 100%);"
+                "color:#fff;font-size:17px;font-weight:600;letter-spacing:.3px;"
+                "box-shadow:0 4px 12px rgba(0,0,0,0.3);cursor:pointer;transition:transform .15s,box-shadow .15s,filter .15s;}"
+                ".button:hover,.button:focus{filter:brightness(1.08);outline:none;}"
+                ".button:active{transform:translateY(1px);box-shadow:0 2px 6px rgba(0,0,0,0.25);filter:brightness(.92);}"
+                ".button.secondary{background:transparent;border:1px solid rgba(255,255,255,0.2);"
+                "box-shadow:none;}"
+                ".button[disabled]{opacity:.55;cursor:not-allowed;box-shadow:none;}"
+                ".status{min-height:22px;margin-top:6px;font-size:14px;color:var(--muted);text-align:center;}"
+                ".status.error{color:var(--error);}"
+                "form{display:flex;flex-direction:column;}"
+            "</style>"
+        "</head>"
+        "<body>"
+            "<div class=\"page\">"
+                "<div class=\"card\">"
+                    "<h1>Access Point Setup</h1>"
+                    "<form method=\"post\" action=\"/api/v1/ap\" autocomplete=\"off\">";
+
+    esp_err_t err = httpd_resp_send_chunk(req, head, strlen(head));
+    if (err != ESP_OK) {
+        httpd_resp_sendstr_chunk(req, NULL);
+        return err;
+    }
+
+    char field_buffer[512];
+    int written = snprintf(field_buffer, sizeof(field_buffer),
+        "<div class=\"%s\">"
+            "<label for=\"ssid\">AP SSID</label>"
+            "<input id=\"ssid\" name=\"ssid\" type=\"text\" maxlength=\"32\" value=\"%s\" required>"
+        "</div>",
+        ssid_field_class,
+        ssid_escaped);
+    if (written < 0 || (size_t)written >= sizeof(field_buffer)) {
+        httpd_resp_sendstr_chunk(req, NULL);
+        return ESP_ERR_INVALID_SIZE;
+    }
+    err = httpd_resp_send_chunk(req, field_buffer, written);
+    if (err != ESP_OK) {
+        httpd_resp_sendstr_chunk(req, NULL);
+        return err;
+    }
+
+    written = snprintf(field_buffer, sizeof(field_buffer),
+        "<div class=\"%s\">"
+            "<label for=\"password\">AP Password</label>"
+            "<input id=\"password\" name=\"password\" type=\"password\" maxlength=\"64\" value=\"%s\" required>"
+        "</div>",
+        password_field_class,
+        password_escaped);
+    if (written < 0 || (size_t)written >= sizeof(field_buffer)) {
+        httpd_resp_sendstr_chunk(req, NULL);
+        return ESP_ERR_INVALID_SIZE;
+    }
+    err = httpd_resp_send_chunk(req, field_buffer, written);
+    if (err != ESP_OK) {
+        httpd_resp_sendstr_chunk(req, NULL);
+        return err;
+    }
+
+    written = snprintf(field_buffer, sizeof(field_buffer),
+        "<div class=\"%s\">%s</div>"
+        "<div class=\"actions\">"
+            "<button class=\"button\" type=\"submit\">OK</button>"
+            "<button class=\"button secondary\" type=\"button\" style=\"display:%s;\" onclick=\"window.location.href='/api/v1/main'\">Cancel</button>"
+        "</div>"
+        "</form>"
+        "</div>"
+        "</div>"
+        "</body>"
+        "</html>",
+        status_class,
+        status_escaped,
+        cancel_visibility);
+    if (written < 0 || (size_t)written >= sizeof(field_buffer)) {
+        httpd_resp_sendstr_chunk(req, NULL);
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    err = httpd_resp_send_chunk(req, field_buffer, written);
+    if (err != ESP_OK) {
+        httpd_resp_sendstr_chunk(req, NULL);
+        return err;
+    }
+
+    return httpd_resp_sendstr_chunk(req, NULL);
+}
+

--- a/esp32_mcu/components/admin_portal/pages/page_ap.h
+++ b/esp32_mcu/components/admin_portal/pages/page_ap.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <stdbool.h>
+#include "esp_err.h"
+#include "esp_http_server.h"
+
+typedef struct {
+    const char *ssid;
+    const char *password;
+    const char *status_message;
+    bool status_is_error;
+    bool show_cancel;
+    bool highlight_ssid;
+    bool highlight_password;
+} page_ap_context_t;
+
+esp_err_t page_ap_render(httpd_req_t *req, const page_ap_context_t *context);
+

--- a/esp32_mcu/components/admin_portal/pages/page_main.c
+++ b/esp32_mcu/components/admin_portal/pages/page_main.c
@@ -1,0 +1,71 @@
+#include "page_main.h"
+
+#include <stdio.h>
+
+static const char *safe_text(const char *text)
+{
+    return text ? text : "";
+}
+
+esp_err_t page_main_render(httpd_req_t *req, const page_main_context_t *context)
+{
+    if (!req || !context) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    httpd_resp_set_type(req, "text/html; charset=utf-8");
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate");
+
+    const char *version = safe_text(context->version_label);
+
+    const char *page =
+        "<!DOCTYPE html>"
+        "<html lang=\"en\">"
+        "<head>"
+            "<meta charset=\"UTF-8\">"
+            "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+            "<title>TapGate Control</title>"
+            "<style>"
+                "*{box-sizing:border-box;font-family:'Inter','Segoe UI',sans-serif;}"
+                ":root{--bg:#0D1520;--card:#111927;--text:#E6EEF8;--muted:#9CA3AF;--button-height:48px;}"
+                "body{margin:0;background:var(--bg);color:var(--text);min-height:100vh;}"
+                ".page{min-height:100vh;display:flex;align-items:center;justify-content:center;padding:28px;}"
+                ".panel{width:100%;max-width:420px;background:var(--card);border-radius:22px;padding:32px 26px;"
+                "box-shadow:0 20px 45px rgba(8,12,24,0.45);display:flex;flex-direction:column;align-items:center;gap:22px;}"
+                ".logo{height:calc(var(--button-height)*2);object-fit:contain;}"
+                ".buttons{width:100%;display:flex;flex-direction:column;gap:16px;}"
+                ".button{height:var(--button-height);border:none;border-radius:14px;"
+                "background:linear-gradient(135deg,#0b2451 0%,#1c4c8c 45%,#3a8fdd 100%);color:#fff;font-size:17px;font-weight:600;"
+                "letter-spacing:.3px;box-shadow:0 4px 12px rgba(0,0,0,0.3);cursor:pointer;transition:transform .15s,box-shadow .15s,filter .15s;}"
+                ".button:hover,.button:focus{filter:brightness(1.08);outline:none;}"
+                ".button:active{transform:translateY(1px);box-shadow:0 2px 6px rgba(0,0,0,0.25);filter:brightness(.92);}"
+                ".button[disabled]{opacity:.55;cursor:not-allowed;box-shadow:none;}"
+                ".version{font-size:13px;color:var(--muted);text-align:center;margin-top:8px;}"
+            "</style>"
+        "</head>"
+        "<body>"
+            "<div class=\"page\">"
+                "<div class=\"panel\">"
+                    "<img class=\"logo\" src=\"/assets/logo.png\" alt=\"TapGate logo\">"
+                    "<div class=\"buttons\">"
+                        "<button class=\"button\" type=\"button\" disabled>TapGate</button>"
+                        "<button class=\"button\" type=\"button\" onclick=\"window.location.href='/api/v1/ap'\">AP setting</button>"
+                        "<button class=\"button\" type=\"button\" disabled>WiFi connection</button>"
+                        "<button class=\"button\" type=\"button\" disabled>Clients</button>"
+                        "<button class=\"button\" type=\"button\" disabled>Events</button>"
+                    "</div>"
+                    "<div class=\"version\">%s</div>"
+                "</div>"
+            "</div>"
+        "</body>"
+        "</html>";
+
+    char buffer[1024];
+    int written = snprintf(buffer, sizeof(buffer), page, version);
+    if (written < 0 || (size_t)written >= sizeof(buffer)) {
+        return ESP_ERR_INVALID_SIZE;
+    }
+
+    return httpd_resp_send(req, buffer, written);
+}
+

--- a/esp32_mcu/components/admin_portal/pages/page_main.h
+++ b/esp32_mcu/components/admin_portal/pages/page_main.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "esp_err.h"
+#include "esp_http_server.h"
+
+typedef struct {
+    const char *version_label;
+} page_main_context_t;
+
+esp_err_t page_main_render(httpd_req_t *req, const page_main_context_t *context);
+


### PR DESCRIPTION
## Summary
- add a dedicated HTTP service that routes requests, renders the main/AP pages, and serves embedded assets
- implement AP and main portal pages with responsive styling and status handling for credential validation
- create a facade to persist SoftAP credentials, apply them to Wi-Fi, and integrate the service with the existing HTTP server startup

## Testing
- `idf.py build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1b66acd38832ea6331778551cea64