### PR TITLE
Improve enroll page validation and hints

### DIFF
--- a/esp32_mcu/components/admin_portal/assets/page_enroll.html
+++ b/esp32_mcu/components/admin_portal/assets/page_enroll.html
@@ -15,11 +15,11 @@
     <form data-action="enroll" class="form-grid">
       <label>
         Portal name
-        <input type="text" data-bind="portal-name" readonly>
+        <input type="text" name="portal" data-bind="portal-name" required>
       </label>
       <label>
         New password
-        <input type="password" name="password" minlength="8" autocomplete="new-password" required>
+        <input type="password" name="password" minlength="8" autocomplete="new-password" required placeholder="Minimum 8 characters">
       </label>
       <div class="message" data-message></div>
       <button type="submit">Ok</button>


### PR DESCRIPTION
## Summary
- add a placeholder hint to the enrollment password field and require the portal name input
- preload the portal name control with the access point SSID and clear any previous error styling when data arrives
- block enrollment submissions on empty portal names or too-short passwords before sending a request, and refocus the portal field when required

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d436fe1e8c832e87eb08a32dec0e79