### PR TITLE
Serve admin portal initial state inline

### DIFF
--- a/esp32_mcu/components/admin_portal/admin_portal_device.c
+++ b/esp32_mcu/components/admin_portal/admin_portal_device.c
@@ -1,0 +1,51 @@
+#include "admin_portal_device.h"
+
+#include "wifi_manager.h"
+
+#include <string.h>
+
+static size_t strnlen_safe(const char *str, size_t max_len)
+{
+    size_t len = 0;
+    if (!str)
+        return 0;
+    while (len < max_len && str[len] != '\0')
+        ++len;
+    return len;
+}
+
+void admin_portal_device_get_ap_ssid(char *ssid, size_t size)
+{
+    if (!ssid || size == 0)
+        return;
+
+    const char *source = (const char *)wifi_settings.ap_ssid;
+    size_t length = strnlen_safe(source, sizeof(wifi_settings.ap_ssid));
+    if (length >= size)
+        length = size - 1;
+
+    memcpy(ssid, source, length);
+    ssid[length] = '\0';
+}
+
+void admin_portal_device_set_ap_ssid(const char *ssid)
+{
+    if (!ssid)
+        return;
+
+    size_t length = strnlen_safe(ssid, sizeof(wifi_settings.ap_ssid));
+    memcpy(wifi_settings.ap_ssid, ssid, length);
+    if (length < sizeof(wifi_settings.ap_ssid))
+        wifi_settings.ap_ssid[length] = '\0';
+}
+
+void admin_portal_device_set_ap_password(const char *password)
+{
+    if (!password)
+        return;
+
+    size_t length = strnlen_safe(password, sizeof(wifi_settings.ap_pwd));
+    memcpy(wifi_settings.ap_pwd, password, length);
+    if (length < sizeof(wifi_settings.ap_pwd))
+        wifi_settings.ap_pwd[length] = '\0';
+}

--- a/esp32_mcu/components/admin_portal/admin_portal_device.h
+++ b/esp32_mcu/components/admin_portal/admin_portal_device.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <stddef.h>
+
+/**
+ * @brief Copy the currently configured AP SSID into the provided buffer.
+ *
+ * The buffer is always null-terminated when size > 0.
+ */
+void admin_portal_device_get_ap_ssid(char *ssid, size_t size);
+
+/**
+ * @brief Update the in-memory AP SSID used by the device.
+ */
+void admin_portal_device_set_ap_ssid(const char *ssid);
+
+/**
+ * @brief Update the in-memory AP password used by the device.
+ */
+void admin_portal_device_set_ap_password(const char *password);

--- a/esp32_mcu/components/admin_portal/assets/app.js
+++ b/esp32_mcu/components/admin_portal/assets/app.js
@@ -175,6 +175,40 @@
     });
   }
 
+  function applyInitialData() {
+    const initialData = window.TAPGATE_INITIAL_DATA;
+    if (!initialData || !initialData.ap_ssid) {
+      console.log("No initial data from server, falling back to API");
+      refreshSession();
+      return;
+    }
+
+    console.log("Applying initial data from server:", initialData);
+
+    const portalName = initialData.ap_ssid || "";
+
+    document.querySelectorAll("[data-bind='portal-name']").forEach((el) => {
+      if (el.tagName === "INPUT") {
+        if (!el.value.trim()) {
+          el.value = portalName;
+          console.log(`Set portal input value to: "${portalName}"`);
+        }
+        el.defaultValue = portalName;
+        el.classList.remove("error");
+      } else {
+        el.textContent = portalName;
+      }
+    });
+
+    document.querySelectorAll("[data-bind='ssid']").forEach((el) => {
+      if (el.tagName === "INPUT") {
+        el.value = initialData.ap_ssid || "";
+      } else {
+        el.textContent = initialData.ap_ssid || "";
+      }
+    });
+  }
+
   function refreshSession() {
     fetch("/api/session", { method: "GET", cache: "no-store", credentials: "same-origin" })
       .then((response) => response.json().catch(() => null))
@@ -193,8 +227,11 @@
       .catch(() => {});
   }
 
-  refreshSession();
-  document.addEventListener("DOMContentLoaded", () => {
+  function initialize() {
+    console.log("Initializing app...");
     attachForms();
-  });
+    applyInitialData();
+  }
+
+  initialize();
 })();

--- a/esp32_mcu/components/admin_portal/assets/page_auth.html
+++ b/esp32_mcu/components/admin_portal/assets/page_auth.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Sign In</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
   <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-auth">

--- a/esp32_mcu/components/admin_portal/assets/page_busy.html
+++ b/esp32_mcu/components/admin_portal/assets/page_busy.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Busy</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
+  <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-busy">
   <main class="card">

--- a/esp32_mcu/components/admin_portal/assets/page_change_psw.html
+++ b/esp32_mcu/components/admin_portal/assets/page_change_psw.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Change Password</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
   <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-change-password">

--- a/esp32_mcu/components/admin_portal/assets/page_clients.html
+++ b/esp32_mcu/components/admin_portal/assets/page_clients.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Clients</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
   <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-clients">

--- a/esp32_mcu/components/admin_portal/assets/page_device.html
+++ b/esp32_mcu/components/admin_portal/assets/page_device.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Device</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
   <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-device">

--- a/esp32_mcu/components/admin_portal/assets/page_enroll.html
+++ b/esp32_mcu/components/admin_portal/assets/page_enroll.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Enroll</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
   <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-enroll">

--- a/esp32_mcu/components/admin_portal/assets/page_events.html
+++ b/esp32_mcu/components/admin_portal/assets/page_events.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Events</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
   <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-events">

--- a/esp32_mcu/components/admin_portal/assets/page_main.html
+++ b/esp32_mcu/components/admin_portal/assets/page_main.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Dashboard</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
   <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-main">

--- a/esp32_mcu/components/admin_portal/assets/page_off.html
+++ b/esp32_mcu/components/admin_portal/assets/page_off.html
@@ -5,6 +5,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · Disconnected</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
+  <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-off">
   <main class="card">

--- a/esp32_mcu/components/admin_portal/assets/page_wifi.html
+++ b/esp32_mcu/components/admin_portal/assets/page_wifi.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>TapGate · WiFi</title>
   <link rel="stylesheet" href="/assets/styles.css">
+  <script src="/api/initial-data.js"></script>
   <script defer src="/assets/app.js"></script>
 </head>
 <body class="page page-wifi">

--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -159,15 +159,17 @@ static size_t escape_js_string(const char *src, char *dest, size_t dest_size)
     {
         const char *replacement = NULL;
         char buffer[8];
-        buffer[0] = '\0';
 
         switch (*input)
         {
-            case '\':
-                replacement = "\\";
+            case '\\':
+                buffer[0] = '\\';
+                buffer[1] = '\\';
+                buffer[2] = '\0';
+                replacement = buffer;
                 break;
             case '"':
-                replacement = "\"";
+                replacement = "\\\"";
                 break;
             case '\b':
                 replacement = "\b";
@@ -193,7 +195,7 @@ static size_t escape_js_string(const char *src, char *dest, size_t dest_size)
             case '&':
                 replacement = "\u0026";
                 break;
-            case '\'':
+            case 0x27:
                 replacement = "\u0027";
                 break;
             default:

--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -187,16 +187,16 @@ static size_t escape_js_string(const char *src, char *dest, size_t dest_size)
                 replacement = "\t";
                 break;
             case '<':
-                replacement = "\u003C";
+                replacement = "\\u003C";
                 break;
             case '>':
-                replacement = "\u003E";
+                replacement = "\\u003E";
                 break;
             case '&':
-                replacement = "\u0026";
+                replacement = "\\u0026";
                 break;
             case 0x27:
-                replacement = "\u0027";
+                replacement = "\\u0027";
                 break;
             default:
                 if (*input < 0x20)

--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -1,12 +1,13 @@
 #include "http_service.h"
 
 #include "admin_portal_state.h"
+#include "admin_portal_device.h"
 #include "logs.h"
 #include "wifi_manager.h"
+#include "nvm/nvm.h"
 
 #include "esp_random.h"
 #include "esp_timer.h"
-#include "nvs.h"
 
 #include <inttypes.h>
 #include <stdio.h>
@@ -121,16 +122,6 @@ static uint64_t get_now_ms(void)
     return esp_timer_get_time() / 1000ULL;
 }
 
-static size_t strnlen_safe(const char *str, size_t max_len)
-{
-    size_t len = 0;
-    if (!str)
-        return 0;
-    while (len < max_len && str[len] != '\0')
-        ++len;
-    return len;
-}
-
 static uint64_t minutes_to_ms(uint32_t minutes)
 {
     return (uint64_t)minutes * 60ULL * 1000ULL;
@@ -154,6 +145,84 @@ static void set_cache_headers(httpd_req_t *req)
     httpd_resp_set_hdr(req, "Cache-Control", "no-store");
     httpd_resp_set_hdr(req, "Pragma", "no-cache");
     httpd_resp_set_hdr(req, "Expires", "0");
+}
+
+
+static size_t escape_js_string(const char *src, char *dest, size_t dest_size)
+{
+    if (!dest || dest_size == 0)
+        return 0;
+
+    size_t di = 0;
+    const unsigned char *input = (const unsigned char *)(src ? src : "");
+    while (*input && di + 1 < dest_size)
+    {
+        const char *replacement = NULL;
+        char buffer[8];
+        buffer[0] = '\0';
+
+        switch (*input)
+        {
+            case '\':
+                replacement = "\\";
+                break;
+            case '"':
+                replacement = "\"";
+                break;
+            case '\b':
+                replacement = "\b";
+                break;
+            case '\f':
+                replacement = "\f";
+                break;
+            case '\n':
+                replacement = "\n";
+                break;
+            case '\r':
+                replacement = "\r";
+                break;
+            case '\t':
+                replacement = "\t";
+                break;
+            case '<':
+                replacement = "\u003C";
+                break;
+            case '>':
+                replacement = "\u003E";
+                break;
+            case '&':
+                replacement = "\u0026";
+                break;
+            case '\'':
+                replacement = "\u0027";
+                break;
+            default:
+                if (*input < 0x20)
+                {
+                    snprintf(buffer, sizeof(buffer), "\\u%04X", (unsigned)*input);
+                    replacement = buffer;
+                }
+                break;
+        }
+
+        if (replacement)
+        {
+            size_t len = strlen(replacement);
+            if (di + len >= dest_size)
+                break;
+            memcpy(dest + di, replacement, len);
+            di += len;
+        }
+        else
+        {
+            dest[di++] = (char)*input;
+        }
+
+        ++input;
+    }
+
+    dest[di] = '\0';
+    return di;
 }
 
 static void set_session_cookie(httpd_req_t *req, const char *token, uint32_t max_age_seconds)
@@ -227,93 +296,11 @@ static bool get_session_token(httpd_req_t *req, char *token, size_t token_size)
     return found;
 }
 
-static esp_err_t nvm_open_handle(nvs_open_mode mode, nvs_handle_t *handle)
-{
-    if (!handle)
-        return ESP_ERR_INVALID_ARG;
-    return nvs_open_from_partition(NVM_WIFI_PARTITION, ADMIN_PORTAL_NAMESPACE, mode, handle);
-}
-
-static esp_err_t nvm_read_string(const char *key, char *buffer, size_t size)
-{
-    if (!key || !buffer || size == 0)
-        return ESP_ERR_INVALID_ARG;
-
-    nvs_handle_t handle;
-    esp_err_t err = nvm_open_handle(NVS_READONLY, &handle);
-    if (err != ESP_OK)
-    {
-        buffer[0] = '\0';
-        return err;
-    }
-
-    size_t length = size;
-    err = nvs_get_str(handle, key, buffer, &length);
-    if (err == ESP_ERR_NVS_NOT_FOUND)
-    {
-        buffer[0] = '\0';
-        err = ESP_OK;
-    }
-    nvs_close(handle);
-    return err;
-}
-
-static esp_err_t nvm_write_string(const char *key, const char *value)
-{
-    if (!key || !value)
-        return ESP_ERR_INVALID_ARG;
-
-    nvs_handle_t handle;
-    esp_err_t err = nvm_open_handle(NVS_READWRITE, &handle);
-    if (err != ESP_OK)
-        return err;
-
-    err = nvs_set_str(handle, key, value);
-    if (err == ESP_OK)
-        err = nvs_commit(handle);
-    nvs_close(handle);
-    return err;
-}
-
-static esp_err_t nvm_read_u32(const char *key, uint32_t *value)
-{
-    if (!key || !value)
-        return ESP_ERR_INVALID_ARG;
-
-    nvs_handle_t handle;
-    esp_err_t err = nvm_open_handle(NVS_READONLY, &handle);
-    if (err != ESP_OK)
-        return err;
-
-    err = nvs_get_u32(handle, key, value);
-    nvs_close(handle);
-    return err;
-}
-
-static void update_wifi_settings_password(const char *password)
-{
-    if (!password)
-        return;
-    size_t length = strnlen_safe(password, sizeof(wifi_settings.ap_pwd));
-    memcpy(wifi_settings.ap_pwd, password, length);
-    if (length < sizeof(wifi_settings.ap_pwd))
-        wifi_settings.ap_pwd[length] = '\0';
-}
-
-static void update_wifi_settings_ssid(const char *ssid)
-{
-    if (!ssid)
-        return;
-    size_t length = strnlen_safe(ssid, sizeof(wifi_settings.ap_ssid));
-    memcpy(wifi_settings.ap_ssid, ssid, length);
-    if (length < sizeof(wifi_settings.ap_ssid))
-        wifi_settings.ap_ssid[length] = '\0';
-}
-
 static void load_initial_state(void)
 {
     uint32_t stored_minutes = DEFAULT_IDLE_TIMEOUT_MINUTES;
-    if (nvm_read_u32(ADMIN_PORTAL_KEY_IDLE_MIN, &stored_minutes) != ESP_OK || stored_minutes == 0)
+    if (nvm_read_u32(NVM_WIFI_PARTITION, ADMIN_PORTAL_NAMESPACE, ADMIN_PORTAL_KEY_IDLE_MIN, &stored_minutes) != ESP_OK ||
+        stored_minutes == 0)
     {
         stored_minutes = DEFAULT_IDLE_TIMEOUT_MINUTES;
     }
@@ -321,24 +308,22 @@ static void load_initial_state(void)
     admin_portal_state_init(&g_state, (uint32_t)minutes_to_ms(stored_minutes), WPA2_MINIMUM_PASSWORD_LENGTH);
 
     char ssid[sizeof(g_state.ap_ssid)];
-    if (nvm_read_string(ADMIN_PORTAL_KEY_SSID, ssid, sizeof(ssid)) != ESP_OK || ssid[0] == '\0')
+    if (nvm_read_string(NVM_WIFI_PARTITION, ADMIN_PORTAL_NAMESPACE, ADMIN_PORTAL_KEY_SSID, ssid, sizeof(ssid)) != ESP_OK ||
+        ssid[0] == '\0')
     {
-        size_t length = strnlen_safe((const char *)wifi_settings.ap_ssid, sizeof(wifi_settings.ap_ssid));
-        if (length >= sizeof(ssid))
-            length = sizeof(ssid) - 1;
-        memcpy(ssid, wifi_settings.ap_ssid, length);
-        ssid[length] = '\0';
+        admin_portal_device_get_ap_ssid(ssid, sizeof(ssid));
     }
     admin_portal_state_set_ssid(&g_state, ssid);
 
     char password[sizeof(g_state.ap_password)];
-    if (nvm_read_string(ADMIN_PORTAL_KEY_PSW, password, sizeof(password)) != ESP_OK)
+    if (nvm_read_string(NVM_WIFI_PARTITION, ADMIN_PORTAL_NAMESPACE, ADMIN_PORTAL_KEY_PSW, password, sizeof(password)) !=
+        ESP_OK)
     {
         password[0] = '\0';
     }
     admin_portal_state_set_password(&g_state, password);
     if (admin_portal_state_has_password(&g_state))
-        update_wifi_settings_password(password);
+        admin_portal_device_set_ap_password(password);
 
     LOGI(TAG,
          "Initial state loaded: SSID=\"%s\", AP PSW=%s, idle timeout=%" PRIu32 " ms",
@@ -362,6 +347,34 @@ static esp_err_t send_asset(httpd_req_t *req, const admin_portal_asset_t *asset)
 
     size_t length = (size_t)(asset->end - asset->start);
     return httpd_resp_send(req, (const char *)asset->start, length);
+}
+
+
+static esp_err_t send_initial_data_script(httpd_req_t *req)
+{
+    const char *ssid = admin_portal_state_get_ssid(&g_state);
+    bool has_password = admin_portal_state_has_password(&g_state);
+    bool authorized = admin_portal_state_session_authorized(&g_state);
+
+    char escaped_ssid[sizeof(g_state.ap_ssid) * 6 + 1];
+    escape_js_string(ssid, escaped_ssid, sizeof(escaped_ssid));
+
+    char script[512];
+    snprintf(script,
+             sizeof(script),
+             "window.TAPGATE_INITIAL_DATA={ap_ssid:\"%s\",has_password:%s,authorized:%s};",
+             escaped_ssid,
+             has_password ? "true" : "false",
+             authorized ? "true" : "false");
+
+    httpd_resp_set_type(req, "application/javascript");
+    set_cache_headers(req);
+    return httpd_resp_send(req, script, HTTPD_RESP_USE_STRLEN);
+}
+
+static esp_err_t handle_initial_data(httpd_req_t *req)
+{
+    return send_initial_data_script(req);
 }
 
 static esp_err_t send_page_content(httpd_req_t *req, const admin_portal_page_descriptor_t *desc)
@@ -651,14 +664,14 @@ static esp_err_t handle_enroll(httpd_req_t *req)
         return send_json(req, "200 OK", "{\"status\":\"error\",\"code\":\"invalid_password\"}");
     }
 
-    esp_err_t err = nvm_write_string(ADMIN_PORTAL_KEY_SSID, portal_name);
+    esp_err_t err = nvm_write_string(NVM_WIFI_PARTITION, ADMIN_PORTAL_NAMESPACE, ADMIN_PORTAL_KEY_SSID, portal_name);
     if (err != ESP_OK)
     {
         LOGI(TAG, "Enrollment failed: unable to store AP SSID: %s", esp_err_to_name(err));
         return send_json(req, "500 Internal Server Error", "{\"status\":\"error\",\"code\":\"storage_failed\"}");
     }
 
-    err = nvm_write_string(ADMIN_PORTAL_KEY_PSW, password);
+    err = nvm_write_string(NVM_WIFI_PARTITION, ADMIN_PORTAL_NAMESPACE, ADMIN_PORTAL_KEY_PSW, password);
     if (err != ESP_OK)
     {
         LOGI(TAG, "Enrollment failed: unable to store password: %s", esp_err_to_name(err));
@@ -668,7 +681,7 @@ static esp_err_t handle_enroll(httpd_req_t *req)
     admin_portal_state_set_ssid(&g_state, portal_name);
     admin_portal_state_set_password(&g_state, password);
     admin_portal_state_authorize_session(&g_state);
-    update_wifi_settings_password(password);
+    admin_portal_device_set_ap_password(password);
 
     LOGI(TAG, "Enrollment successful, redirecting to main page (AP SSID=\"%s\")", portal_name);
     return send_json(req, "200 OK", "{\"status\":\"ok\",\"redirect\":\"/main/\"}");
@@ -772,7 +785,7 @@ static esp_err_t handle_change_password(httpd_req_t *req)
         return send_json(req, "200 OK", "{\"status\":\"error\",\"code\":\"invalid_new_password\"}");
     }
 
-    esp_err_t err = nvm_write_string(ADMIN_PORTAL_KEY_PSW, next);
+    esp_err_t err = nvm_write_string(NVM_WIFI_PARTITION, ADMIN_PORTAL_NAMESPACE, ADMIN_PORTAL_KEY_PSW, next);
     if (err != ESP_OK)
     {
         LOGI(TAG, "Change password failed: unable to store password (err=0x%x)", (unsigned)err);
@@ -781,7 +794,7 @@ static esp_err_t handle_change_password(httpd_req_t *req)
 
     admin_portal_state_set_password(&g_state, next);
     admin_portal_state_authorize_session(&g_state);
-    update_wifi_settings_password(next);
+    admin_portal_device_set_ap_password(next);
 
     LOGI(TAG, "Change password successful, redirecting to device page");
     return send_json(req, "200 OK", "{\"status\":\"ok\",\"redirect\":\"/device/\"}");
@@ -824,7 +837,7 @@ static esp_err_t handle_update_device(httpd_req_t *req)
         return send_json(req, "200 OK", "{\"status\":\"error\",\"code\":\"invalid_ssid\"}");
     }
 
-    esp_err_t err = nvm_write_string(ADMIN_PORTAL_KEY_SSID, ssid);
+    esp_err_t err = nvm_write_string(NVM_WIFI_PARTITION, ADMIN_PORTAL_NAMESPACE, ADMIN_PORTAL_KEY_SSID, ssid);
     if (err != ESP_OK)
     {
         LOGI(TAG, "Device update failed: unable to store SSID (err=0x%x)", (unsigned)err);
@@ -832,7 +845,7 @@ static esp_err_t handle_update_device(httpd_req_t *req)
     }
 
     admin_portal_state_set_ssid(&g_state, ssid);
-    update_wifi_settings_ssid(ssid);
+    admin_portal_device_set_ap_ssid(ssid);
 
     LOGI(TAG, "Device update successful, redirecting to main page (ssid=\"%s\")", ssid);
     return send_json(req, "200 OK", "{\"status\":\"ok\",\"redirect\":\"/main/\"}");
@@ -979,6 +992,15 @@ esp_err_t admin_portal_http_service_start(httpd_handle_t server)
         };
         ESP_ERROR_CHECK(httpd_register_uri_handler(server, &asset_uri));
     }
+
+
+    httpd_uri_t initial_data = {
+        .uri = "/api/initial-data.js",
+        .method = HTTP_GET,
+        .handler = handle_initial_data,
+        .user_ctx = NULL,
+    };
+    ESP_ERROR_CHECK(httpd_register_uri_handler(server, &initial_data));
 
     httpd_uri_t api_session = {
         .uri = "/api/session",

--- a/esp32_mcu/components/common/nvm/nvm.h
+++ b/esp32_mcu/components/common/nvm/nvm.h
@@ -2,4 +2,28 @@
 
 #include "esp_err.h"
 
+#include <stddef.h>
+#include <stdint.h>
+
 esp_err_t nvm_init(void);
+
+esp_err_t nvm_read_string(const char *partition,
+                          const char *namespace_name,
+                          const char *key,
+                          char *buffer,
+                          size_t size);
+
+esp_err_t nvm_write_string(const char *partition,
+                           const char *namespace_name,
+                           const char *key,
+                           const char *value);
+
+esp_err_t nvm_read_u32(const char *partition,
+                       const char *namespace_name,
+                       const char *key,
+                       uint32_t *value);
+
+esp_err_t nvm_write_u32(const char *partition,
+                        const char *namespace_name,
+                        const char *key,
+                        uint32_t value);

--- a/esp32_mcu/tests_host/mocks/include/nvs.h
+++ b/esp32_mcu/tests_host/mocks/include/nvs.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "esp_err.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef uint32_t nvs_handle_t;
+
+typedef enum {
+    NVS_READONLY = 0,
+    NVS_READWRITE = 1,
+} nvs_open_mode;
+
+esp_err_t nvs_open_from_partition(const char *partition_name,
+                                  const char *namespace_name,
+                                  nvs_open_mode open_mode,
+                                  nvs_handle_t *out_handle);
+esp_err_t nvs_get_str(nvs_handle_t handle, const char *key, char *out_value, size_t *length);
+esp_err_t nvs_set_str(nvs_handle_t handle, const char *key, const char *value);
+esp_err_t nvs_get_u32(nvs_handle_t handle, const char *key, uint32_t *out_value);
+esp_err_t nvs_set_u32(nvs_handle_t handle, const char *key, uint32_t value);
+esp_err_t nvs_commit(nvs_handle_t handle);
+void nvs_close(nvs_handle_t handle);
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
## Summary
- add a JavaScript escaping helper and register a `/api/initial-data.js` endpoint that returns the current portal state from the HTTP service
- load the new inline data script on every admin page and teach the frontend to apply the data before falling back to `/api/session`

## Testing
- cmake -S esp32_mcu/tests_host -B esp32_mcu/tests_host/build
- cmake --build esp32_mcu/tests_host/build
- ctest --test-dir esp32_mcu/tests_host/build


------
https://chatgpt.com/codex/tasks/task_e_68d477766b90832ea3670abb03b48d96