### PR TITLE
Implement admin portal v2

### DIFF
--- a/esp32_mcu/components/admin_portal/admin_portal_device.c
+++ b/esp32_mcu/components/admin_portal/admin_portal_device.c
@@ -56,6 +56,7 @@ esp_err_t admin_portal_device_load(admin_portal_state_t *state)
             LOGW(TAG, "Using default inactivity timeout due to read error: %s", esp_err_to_name(timeout_err));
         }
         timeout_minutes = ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN;
+        timeout_err = ESP_OK;
     }
     admin_portal_state_update_timeout(state, minutes_to_ms(timeout_minutes));
 

--- a/esp32_mcu/components/admin_portal/admin_portal_device.c
+++ b/esp32_mcu/components/admin_portal/admin_portal_device.c
@@ -1,0 +1,111 @@
+#include "admin_portal_device.h"
+
+#include "logs.h"
+#include "nvm/nvm.h"
+
+#include <stdint.h>
+#include <string.h>
+
+static const char *TAG = "admin_portal_device";
+
+static uint32_t minutes_to_ms(uint32_t minutes)
+{
+    if (minutes == 0)
+        return 0;
+    uint64_t value = (uint64_t)minutes * 60ULL * 1000ULL;
+    if (value > UINT32_MAX)
+        return UINT32_MAX;
+    return (uint32_t)value;
+}
+
+esp_err_t admin_portal_device_load(admin_portal_state_t *state)
+{
+    if (!state)
+        return ESP_ERR_INVALID_ARG;
+
+    char ssid[MAX_SSID_SIZE] = {0};
+    esp_err_t err = nvm_wifi_read_string(ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_SSID, ssid, sizeof(ssid));
+    if (err != ESP_OK || ssid[0] == '\0')
+    {
+        if (err != ESP_OK)
+        {
+            LOGW(TAG, "Falling back to default SSID due to read error: %s", esp_err_to_name(err));
+        }
+        strncpy(ssid, DEFAULT_AP_SSID, sizeof(ssid) - 1);
+        ssid[sizeof(ssid) - 1] = '\0';
+        err = ESP_OK;
+    }
+    admin_portal_state_set_ssid(state, ssid);
+
+    char password[MAX_PASSWORD_SIZE] = {0};
+    esp_err_t pass_err = nvm_wifi_read_string(ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_PSW, password, sizeof(password));
+    if (pass_err != ESP_OK)
+    {
+        LOGW(TAG, "AP password not found in NVM: %s", esp_err_to_name(pass_err));
+        password[0] = '\0';
+        pass_err = ESP_OK;
+    }
+    admin_portal_state_set_password(state, password);
+
+    uint32_t timeout_minutes = ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN;
+    esp_err_t timeout_err = nvm_wifi_read_u32(ADMIN_PORTAL_NVM_NAMESPACE_KEY_IDLE_TIMEOUT, &timeout_minutes);
+    if (timeout_err != ESP_OK || timeout_minutes == 0)
+    {
+        if (timeout_err != ESP_OK)
+        {
+            LOGW(TAG, "Using default inactivity timeout due to read error: %s", esp_err_to_name(timeout_err));
+        }
+        timeout_minutes = ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN;
+    }
+    admin_portal_state_update_timeout(state, minutes_to_ms(timeout_minutes));
+
+    return (err != ESP_OK) ? err : (pass_err != ESP_OK ? pass_err : timeout_err);
+}
+
+esp_err_t admin_portal_device_save_password(admin_portal_state_t *state, const char *password)
+{
+    if (!state || !password)
+        return ESP_ERR_INVALID_ARG;
+
+    esp_err_t err = nvm_wifi_write_string(ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_PSW, password);
+    if (err != ESP_OK)
+    {
+        LOGE(TAG, "Failed to store admin password: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    admin_portal_state_set_password(state, password);
+    return ESP_OK;
+}
+
+esp_err_t admin_portal_device_save_ssid(admin_portal_state_t *state, const char *ssid)
+{
+    if (!state || !ssid)
+        return ESP_ERR_INVALID_ARG;
+
+    esp_err_t err = nvm_wifi_write_string(ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_SSID, ssid);
+    if (err != ESP_OK)
+    {
+        LOGE(TAG, "Failed to store admin portal SSID: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    admin_portal_state_set_ssid(state, ssid);
+    return ESP_OK;
+}
+
+esp_err_t admin_portal_device_save_timeout(admin_portal_state_t *state, uint32_t minutes)
+{
+    if (!state)
+        return ESP_ERR_INVALID_ARG;
+
+    esp_err_t err = nvm_wifi_write_u32(ADMIN_PORTAL_NVM_NAMESPACE_KEY_IDLE_TIMEOUT, minutes);
+    if (err != ESP_OK)
+    {
+        LOGE(TAG, "Failed to persist inactivity timeout: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    admin_portal_state_update_timeout(state, minutes_to_ms(minutes));
+    return ESP_OK;
+}

--- a/esp32_mcu/components/admin_portal/admin_portal_device.h
+++ b/esp32_mcu/components/admin_portal/admin_portal_device.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "admin_portal_state.h"
+
+#include "esp_err.h"
+
+#define ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_SSID "AP_SSID"
+#define ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_PSW "AP_PSW"
+#define ADMIN_PORTAL_NVM_NAMESPACE_KEY_IDLE_TIMEOUT "AP_IDLE_TIMEOUT"
+
+#define ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN 15U
+
+esp_err_t admin_portal_device_load(admin_portal_state_t *state);
+esp_err_t admin_portal_device_save_password(admin_portal_state_t *state, const char *password);
+esp_err_t admin_portal_device_save_ssid(admin_portal_state_t *state, const char *ssid);
+esp_err_t admin_portal_device_save_timeout(admin_portal_state_t *state, uint32_t minutes);

--- a/esp32_mcu/components/admin_portal/admin_portal_state.c
+++ b/esp32_mcu/components/admin_portal/admin_portal_state.c
@@ -1,0 +1,263 @@
+#include "admin_portal_state.h"
+
+#include <string.h>
+
+static bool page_requires_authorization(admin_portal_page_t page)
+{
+    switch (page)
+    {
+    case ADMIN_PORTAL_PAGE_MAIN:
+    case ADMIN_PORTAL_PAGE_DEVICE:
+    case ADMIN_PORTAL_PAGE_WIFI:
+    case ADMIN_PORTAL_PAGE_CLIENTS:
+    case ADMIN_PORTAL_PAGE_EVENTS:
+    case ADMIN_PORTAL_PAGE_CHANGE_PASSWORD:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void admin_portal_state_init(admin_portal_state_t *state,
+                             uint32_t timeout_ms,
+                             uint8_t min_pwd_len)
+{
+    if (!state)
+        return;
+
+    memset(state, 0, sizeof(*state));
+    state->min_password_length = min_pwd_len;
+    state->inactivity_timeout_ms = timeout_ms;
+}
+
+void admin_portal_state_update_timeout(admin_portal_state_t *state, uint32_t timeout_ms)
+{
+    if (!state)
+        return;
+    state->inactivity_timeout_ms = timeout_ms;
+}
+
+void admin_portal_state_set_ssid(admin_portal_state_t *state, const char *ssid)
+{
+    if (!state)
+        return;
+
+    if (!ssid)
+    {
+        state->ap_ssid[0] = '\0';
+        return;
+    }
+
+    size_t length = strnlen(ssid, MAX_SSID_SIZE - 1);
+    memcpy(state->ap_ssid, ssid, length);
+    state->ap_ssid[length] = '\0';
+}
+
+const char *admin_portal_state_get_ssid(const admin_portal_state_t *state)
+{
+    if (!state)
+        return "";
+    return state->ap_ssid;
+}
+
+void admin_portal_state_set_password(admin_portal_state_t *state, const char *password)
+{
+    if (!state)
+        return;
+
+    if (!password)
+    {
+        state->ap_password[0] = '\0';
+        state->password_length = 0;
+        return;
+    }
+
+    size_t length = strnlen(password, MAX_PASSWORD_SIZE - 1);
+    memcpy(state->ap_password, password, length);
+    state->ap_password[length] = '\0';
+    state->password_length = length;
+}
+
+bool admin_portal_state_verify_password(const admin_portal_state_t *state, const char *password)
+{
+    if (!state)
+        return false;
+    if (!password)
+        return false;
+    if (!state->password_length)
+        return false;
+    size_t length = strnlen(password, MAX_PASSWORD_SIZE - 1);
+    if (length != state->password_length)
+        return false;
+    return memcmp(state->ap_password, password, length) == 0;
+}
+
+bool admin_portal_state_has_password(const admin_portal_state_t *state)
+{
+    if (!state)
+        return false;
+    return state->password_length >= state->min_password_length;
+}
+
+bool admin_portal_state_password_valid(const admin_portal_state_t *state, const char *password)
+{
+    if (!state || !password)
+        return false;
+    size_t length = strnlen(password, MAX_PASSWORD_SIZE);
+    if (length >= MAX_PASSWORD_SIZE)
+        return false;
+    return length >= state->min_password_length;
+}
+
+static void clear_session(admin_portal_session_t *session)
+{
+    if (!session)
+        return;
+    memset(session, 0, sizeof(*session));
+}
+
+void admin_portal_state_clear_session(admin_portal_state_t *state)
+{
+    if (!state)
+        return;
+    clear_session(&state->session);
+}
+
+void admin_portal_state_start_session(admin_portal_state_t *state,
+                                      const char *token,
+                                      uint64_t now_ms,
+                                      bool authorized)
+{
+    if (!state)
+        return;
+
+    clear_session(&state->session);
+    if (!token || !token[0])
+        return;
+
+    size_t length = strnlen(token, ADMIN_PORTAL_SESSION_TOKEN_LENGTH);
+    memcpy(state->session.token, token, length);
+    state->session.token[length] = '\0';
+    state->session.active = true;
+    state->session.authorized = authorized;
+    state->session.last_activity_ms = now_ms;
+}
+
+void admin_portal_state_authorize_session(admin_portal_state_t *state)
+{
+    if (!state)
+        return;
+    if (!state->session.active)
+        return;
+    state->session.authorized = true;
+}
+
+bool admin_portal_state_session_active(const admin_portal_state_t *state)
+{
+    if (!state)
+        return false;
+    return state->session.active;
+}
+
+bool admin_portal_state_session_authorized(const admin_portal_state_t *state)
+{
+    if (!state)
+        return false;
+    return state->session.active && state->session.authorized;
+}
+
+static bool session_has_expired(const admin_portal_state_t *state, uint64_t now_ms)
+{
+    if (!state || !state->session.active)
+        return false;
+    uint32_t timeout = state->inactivity_timeout_ms;
+    if (timeout == 0)
+        return false;
+    if (now_ms < state->session.last_activity_ms)
+        return false;
+    return (now_ms - state->session.last_activity_ms) >= timeout;
+}
+
+admin_portal_session_status_t admin_portal_state_check_session(admin_portal_state_t *state,
+                                                               const char *token,
+                                                               uint64_t now_ms)
+{
+    if (!state)
+        return ADMIN_PORTAL_SESSION_NONE;
+
+    if (session_has_expired(state, now_ms))
+    {
+        clear_session(&state->session);
+        return ADMIN_PORTAL_SESSION_EXPIRED;
+    }
+
+    if (!state->session.active)
+        return ADMIN_PORTAL_SESSION_NONE;
+
+    if (!token || !token[0])
+        return ADMIN_PORTAL_SESSION_NONE;
+
+    size_t length = strnlen(token, ADMIN_PORTAL_SESSION_TOKEN_LENGTH);
+    if (strncmp(state->session.token, token, length) == 0 &&
+        strnlen(state->session.token, ADMIN_PORTAL_SESSION_TOKEN_LENGTH) == length)
+    {
+        state->session.last_activity_ms = now_ms;
+        return ADMIN_PORTAL_SESSION_MATCH;
+    }
+
+    if (admin_portal_state_has_password(state))
+        return ADMIN_PORTAL_SESSION_BUSY;
+
+    return ADMIN_PORTAL_SESSION_NONE;
+}
+
+static bool should_redirect_to_enroll(const admin_portal_state_t *state,
+                                      admin_portal_page_t requested_page)
+{
+    if (!state)
+        return false;
+    if (admin_portal_state_has_password(state))
+        return false;
+    return requested_page != ADMIN_PORTAL_PAGE_ENROLL &&
+           requested_page != ADMIN_PORTAL_PAGE_BUSY &&
+           requested_page != ADMIN_PORTAL_PAGE_OFF;
+}
+
+admin_portal_page_t admin_portal_state_resolve_page(const admin_portal_state_t *state,
+                                                    admin_portal_page_t requested_page,
+                                                    admin_portal_session_status_t session_status)
+{
+    if (!state)
+        return requested_page;
+
+    switch (session_status)
+    {
+    case ADMIN_PORTAL_SESSION_BUSY:
+        return ADMIN_PORTAL_PAGE_BUSY;
+    case ADMIN_PORTAL_SESSION_EXPIRED:
+        return ADMIN_PORTAL_PAGE_OFF;
+    default:
+        break;
+    }
+
+    if (requested_page == ADMIN_PORTAL_PAGE_BUSY || requested_page == ADMIN_PORTAL_PAGE_OFF)
+        return requested_page;
+
+    if (should_redirect_to_enroll(state, requested_page))
+        return ADMIN_PORTAL_PAGE_ENROLL;
+
+    if (!admin_portal_state_has_password(state))
+        return ADMIN_PORTAL_PAGE_ENROLL;
+
+    if (requested_page == ADMIN_PORTAL_PAGE_ENROLL)
+        return ADMIN_PORTAL_PAGE_AUTH;
+
+    bool authorized = admin_portal_state_session_authorized(state);
+    if (!authorized && page_requires_authorization(requested_page))
+        return ADMIN_PORTAL_PAGE_AUTH;
+
+    if (authorized && requested_page == ADMIN_PORTAL_PAGE_AUTH)
+        return ADMIN_PORTAL_PAGE_MAIN;
+
+    return requested_page;
+}

--- a/esp32_mcu/components/admin_portal/admin_portal_state.h
+++ b/esp32_mcu/components/admin_portal/admin_portal_state.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include "wifi_manager.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#define ADMIN_PORTAL_SESSION_TOKEN_LENGTH 32
+
+typedef enum {
+    ADMIN_PORTAL_PAGE_ENROLL = 0,
+    ADMIN_PORTAL_PAGE_AUTH,
+    ADMIN_PORTAL_PAGE_MAIN,
+    ADMIN_PORTAL_PAGE_DEVICE,
+    ADMIN_PORTAL_PAGE_WIFI,
+    ADMIN_PORTAL_PAGE_CLIENTS,
+    ADMIN_PORTAL_PAGE_EVENTS,
+    ADMIN_PORTAL_PAGE_CHANGE_PASSWORD,
+    ADMIN_PORTAL_PAGE_BUSY,
+    ADMIN_PORTAL_PAGE_OFF,
+    ADMIN_PORTAL_PAGE_COUNT
+} admin_portal_page_t;
+
+typedef enum {
+    ADMIN_PORTAL_SESSION_NONE = 0,
+    ADMIN_PORTAL_SESSION_MATCH,
+    ADMIN_PORTAL_SESSION_BUSY,
+    ADMIN_PORTAL_SESSION_EXPIRED
+} admin_portal_session_status_t;
+
+typedef struct {
+    bool active;
+    bool authorized;
+    uint64_t last_activity_ms;
+    char token[ADMIN_PORTAL_SESSION_TOKEN_LENGTH + 1];
+} admin_portal_session_t;
+
+typedef struct {
+    admin_portal_session_t session;
+    char ap_ssid[MAX_SSID_SIZE];
+    char ap_password[MAX_PASSWORD_SIZE];
+    size_t password_length;
+    uint32_t inactivity_timeout_ms;
+    uint8_t min_password_length;
+} admin_portal_state_t;
+
+void admin_portal_state_init(admin_portal_state_t *state,
+                             uint32_t timeout_ms,
+                             uint8_t min_pwd_len);
+
+void admin_portal_state_update_timeout(admin_portal_state_t *state, uint32_t timeout_ms);
+
+void admin_portal_state_set_ssid(admin_portal_state_t *state, const char *ssid);
+const char *admin_portal_state_get_ssid(const admin_portal_state_t *state);
+
+void admin_portal_state_set_password(admin_portal_state_t *state, const char *password);
+bool admin_portal_state_verify_password(const admin_portal_state_t *state, const char *password);
+
+bool admin_portal_state_has_password(const admin_portal_state_t *state);
+bool admin_portal_state_password_valid(const admin_portal_state_t *state, const char *password);
+
+admin_portal_session_status_t admin_portal_state_check_session(admin_portal_state_t *state,
+                                                               const char *token,
+                                                               uint64_t now_ms);
+void admin_portal_state_start_session(admin_portal_state_t *state,
+                                      const char *token,
+                                      uint64_t now_ms,
+                                      bool authorized);
+void admin_portal_state_authorize_session(admin_portal_state_t *state);
+void admin_portal_state_clear_session(admin_portal_state_t *state);
+
+bool admin_portal_state_session_active(const admin_portal_state_t *state);
+bool admin_portal_state_session_authorized(const admin_portal_state_t *state);
+
+admin_portal_page_t admin_portal_state_resolve_page(const admin_portal_state_t *state,
+                                                    admin_portal_page_t requested_page,
+                                                    admin_portal_session_status_t session_status);

--- a/esp32_mcu/components/admin_portal/http_server.c
+++ b/esp32_mcu/components/admin_portal/http_server.c
@@ -1,6 +1,7 @@
 #include "http_server.h"
 
 #include "esp_http_server.h"
+#include "http_service.h"
 #include "logs.h"
 
 static const char TAG[] = "HTTP Server";
@@ -23,6 +24,14 @@ esp_err_t http_server_start()
         return err;
     }
 
+    esp_err_t svc_err = admin_portal_http_service_start(httpserver_handle);
+    if (svc_err != ESP_OK)
+    {
+        LOGE(TAG, "Failed to start admin portal service: %s", esp_err_to_name(svc_err));
+        http_server_stop();
+        return svc_err;
+    }
+
     LOGI(TAG, "HTTP server started");
     return ESP_OK;
 }
@@ -32,6 +41,7 @@ void http_server_stop()
     if (httpserver_handle == NULL)
         return;
 
+    admin_portal_http_service_stop();
     httpd_stop(httpserver_handle);
     httpserver_handle = NULL;
     LOGI(TAG, "HTTP server stopped");

--- a/esp32_mcu/components/admin_portal/http_server.c
+++ b/esp32_mcu/components/admin_portal/http_server.c
@@ -14,7 +14,7 @@ esp_err_t http_server_start()
         return ESP_ERR_INVALID_STATE;
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
-    config.max_uri_handlers = 32;
+    config.max_uri_handlers = 64;
     config.lru_purge_enable = true;
     config.max_req_hdr_len = 1024;
 

--- a/esp32_mcu/components/admin_portal/http_server.c
+++ b/esp32_mcu/components/admin_portal/http_server.c
@@ -16,6 +16,7 @@ esp_err_t http_server_start()
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.max_uri_handlers = 32;
     config.lru_purge_enable = true;
+    config.max_req_hdr_len = 1024;
 
     esp_err_t err = httpd_start(&httpserver_handle, &config);
     if (err != ESP_OK)

--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -1,0 +1,888 @@
+#include "http_service.h"
+
+#include "admin_portal_device.h"
+#include "admin_portal_state.h"
+#include "logs.h"
+#include "pages/page_auth.h"
+#include "pages/page_busy.h"
+#include "pages/page_change_psw.h"
+#include "pages/page_clients.h"
+#include "pages/page_device.h"
+#include "pages/page_enroll.h"
+#include "pages/page_events.h"
+#include "pages/page_main.h"
+#include "pages/page_off.h"
+#include "pages/page_wifi.h"
+
+#include "esp_timer.h"
+#include "esp_system.h"
+
+#include <ctype.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const char *TAG = "admin_http";
+
+static admin_portal_state_t g_state;
+static httpd_handle_t g_server = NULL;
+static bool g_service_started = false;
+
+static uint64_t current_time_ms(void)
+{
+    return (uint64_t)esp_timer_get_time() / 1000ULL;
+}
+
+static void set_no_cache_headers(httpd_req_t *req)
+{
+    httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate");
+    httpd_resp_set_hdr(req, "Pragma", "no-cache");
+    httpd_resp_set_hdr(req, "Expires", "0");
+}
+
+static void set_cache_headers_static(httpd_req_t *req)
+{
+    httpd_resp_set_hdr(req, "Cache-Control", "public, max-age=86400");
+}
+
+static void set_session_cookie(httpd_req_t *req, const char *token)
+{
+    if (!token)
+        return;
+    uint32_t max_age = g_state.inactivity_timeout_ms / 1000U;
+    if (max_age == 0)
+        max_age = ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN * 60U;
+    char buffer[128];
+    snprintf(buffer, sizeof(buffer),
+             "tg_session=%s; Path=/; Max-Age=%u; HttpOnly; SameSite=Lax",
+             token, max_age);
+    httpd_resp_set_hdr(req, "Set-Cookie", buffer);
+}
+
+static void clear_session_cookie(httpd_req_t *req)
+{
+    httpd_resp_set_hdr(req, "Set-Cookie",
+                       "tg_session=; Path=/; Max-Age=0; HttpOnly; SameSite=Lax");
+}
+
+static bool get_session_token(httpd_req_t *req, char *buffer, size_t buffer_len)
+{
+    if (!buffer || buffer_len == 0)
+        return false;
+    size_t cookie_len = httpd_req_get_hdr_value_len(req, "Cookie");
+    if (cookie_len == 0 || cookie_len + 1 > buffer_len)
+        return false;
+    if (httpd_req_get_hdr_value_str(req, "Cookie", buffer, buffer_len) != ESP_OK)
+        return false;
+
+    const char *needle = "tg_session=";
+    char *start = strstr(buffer, needle);
+    if (!start)
+        return false;
+    start += strlen(needle);
+    size_t i = 0;
+    while (start[i] && start[i] != ';' && !isspace((unsigned char)start[i]) && i < ADMIN_PORTAL_SESSION_TOKEN_LENGTH)
+    {
+        buffer[i] = start[i];
+        ++i;
+    }
+    buffer[i] = '\0';
+    return i > 0;
+}
+
+static void generate_session_token(char *buffer, size_t buffer_len)
+{
+    if (!buffer || buffer_len == 0)
+        return;
+
+    uint8_t raw[ADMIN_PORTAL_SESSION_TOKEN_LENGTH / 2] = {0};
+    esp_fill_random(raw, sizeof(raw));
+
+    static const char hex[] = "0123456789abcdef";
+    size_t pos = 0;
+    for (size_t i = 0; i < sizeof(raw) && pos + 1 < buffer_len; ++i)
+    {
+        buffer[pos++] = hex[(raw[i] >> 4) & 0x0F];
+        if (pos < buffer_len - 1)
+            buffer[pos++] = hex[raw[i] & 0x0F];
+    }
+    buffer[pos < buffer_len ? pos : buffer_len - 1] = '\0';
+}
+
+typedef struct {
+    const char *path;
+    const uint8_t *data;
+    size_t size;
+    const char *content_type;
+    bool compressed;
+} admin_portal_asset_t;
+
+extern const uint8_t _binary_app_js_gz_start[];
+extern const uint8_t _binary_app_js_gz_end[];
+extern const uint8_t _binary_styles_css_gz_start[];
+extern const uint8_t _binary_styles_css_gz_end[];
+extern const uint8_t _binary_logo_png_start[];
+extern const uint8_t _binary_logo_png_end[];
+extern const uint8_t _binary_settings_svg_start[];
+extern const uint8_t _binary_settings_svg_end[];
+extern const uint8_t _binary_lock_svg_start[];
+extern const uint8_t _binary_lock_svg_end[];
+extern const uint8_t _binary_wifi0_svg_start[];
+extern const uint8_t _binary_wifi0_svg_end[];
+extern const uint8_t _binary_wifi1_svg_start[];
+extern const uint8_t _binary_wifi1_svg_end[];
+extern const uint8_t _binary_wifi2_svg_start[];
+extern const uint8_t _binary_wifi2_svg_end[];
+extern const uint8_t _binary_wifi3_svg_start[];
+extern const uint8_t _binary_wifi3_svg_end[];
+
+static const admin_portal_asset_t g_assets[] = {
+    {"/assets/app.js", _binary_app_js_gz_start, (size_t)(_binary_app_js_gz_end - _binary_app_js_gz_start), "application/javascript", true},
+    {"/assets/styles.css", _binary_styles_css_gz_start, (size_t)(_binary_styles_css_gz_end - _binary_styles_css_gz_start), "text/css", true},
+    {"/assets/logo.png", _binary_logo_png_start, (size_t)(_binary_logo_png_end - _binary_logo_png_start), "image/png", false},
+    {"/assets/settings.svg", _binary_settings_svg_start, (size_t)(_binary_settings_svg_end - _binary_settings_svg_start), "image/svg+xml", false},
+    {"/assets/lock.svg", _binary_lock_svg_start, (size_t)(_binary_lock_svg_end - _binary_lock_svg_start), "image/svg+xml", false},
+    {"/assets/wifi0.svg", _binary_wifi0_svg_start, (size_t)(_binary_wifi0_svg_end - _binary_wifi0_svg_start), "image/svg+xml", false},
+    {"/assets/wifi1.svg", _binary_wifi1_svg_start, (size_t)(_binary_wifi1_svg_end - _binary_wifi1_svg_start), "image/svg+xml", false},
+    {"/assets/wifi2.svg", _binary_wifi2_svg_start, (size_t)(_binary_wifi2_svg_end - _binary_wifi2_svg_start), "image/svg+xml", false},
+    {"/assets/wifi3.svg", _binary_wifi3_svg_start, (size_t)(_binary_wifi3_svg_end - _binary_wifi3_svg_start), "image/svg+xml", false},
+};
+
+static const admin_portal_page_descriptor_t *g_pages[] = {
+    admin_portal_page_auth_descriptor(),
+    admin_portal_page_busy_descriptor(),
+    admin_portal_page_change_psw_descriptor(),
+    admin_portal_page_clients_descriptor(),
+    admin_portal_page_device_descriptor(),
+    admin_portal_page_enroll_descriptor(),
+    admin_portal_page_events_descriptor(),
+    admin_portal_page_main_descriptor(),
+    admin_portal_page_off_descriptor(),
+    admin_portal_page_wifi_descriptor(),
+};
+
+static const admin_portal_page_descriptor_t *find_page_by_uri(const char *uri)
+{
+    if (!uri)
+        return NULL;
+    for (size_t i = 0; i < sizeof(g_pages) / sizeof(g_pages[0]); ++i)
+    {
+        if (strcmp(g_pages[i]->uri, uri) == 0)
+            return g_pages[i];
+    }
+    return NULL;
+}
+
+static const admin_portal_page_descriptor_t *find_page_by_type(admin_portal_page_t page)
+{
+    for (size_t i = 0; i < sizeof(g_pages) / sizeof(g_pages[0]); ++i)
+    {
+        if (g_pages[i]->page == page)
+            return g_pages[i];
+    }
+    return NULL;
+}
+
+static esp_err_t send_asset(httpd_req_t *req, const admin_portal_asset_t *asset)
+{
+    if (!asset)
+        return ESP_ERR_NOT_FOUND;
+    httpd_resp_set_type(req, asset->content_type);
+    if (asset->compressed)
+        httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
+    set_cache_headers_static(req);
+    return httpd_resp_send(req, (const char *)asset->data, asset->size);
+}
+
+static esp_err_t handle_asset(httpd_req_t *req)
+{
+    const admin_portal_asset_t *asset = (const admin_portal_asset_t *)req->user_ctx;
+    if (!asset)
+    {
+        httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Not Found");
+        return ESP_FAIL;
+    }
+    return send_asset(req, asset);
+}
+
+static esp_err_t send_page_response(httpd_req_t *req, const admin_portal_page_descriptor_t *descriptor)
+{
+    if (!descriptor)
+    {
+        httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Not Found");
+        return ESP_FAIL;
+    }
+
+    httpd_resp_set_type(req, descriptor->content_type);
+    if (descriptor->compressed)
+        httpd_resp_set_hdr(req, "Content-Encoding", "gzip");
+    set_no_cache_headers(req);
+    return httpd_resp_send(req, (const char *)descriptor->data, descriptor->size);
+}
+
+static void escape_js_string(char *dest, size_t dest_len, const char *src)
+{
+    if (!dest || dest_len == 0)
+        return;
+    size_t pos = 0;
+    if (!src)
+    {
+        dest[0] = '\0';
+        return;
+    }
+    while (*src && pos + 1 < dest_len)
+    {
+        char c = *src++;
+        switch (c)
+        {
+        case '\\':
+        case '"':
+            if (pos + 2 >= dest_len)
+            {
+                dest[pos] = '\0';
+                return;
+            }
+            dest[pos++] = '\\';
+            dest[pos++] = c;
+            break;
+        case '\n':
+            if (pos + 2 >= dest_len)
+            {
+                dest[pos] = '\0';
+                return;
+            }
+            dest[pos++] = '\\';
+            dest[pos++] = 'n';
+            break;
+        case '\r':
+            if (pos + 2 >= dest_len)
+            {
+                dest[pos] = '\0';
+                return;
+            }
+            dest[pos++] = '\\';
+            dest[pos++] = 'r';
+            break;
+        case '\t':
+            if (pos + 2 >= dest_len)
+            {
+                dest[pos] = '\0';
+                return;
+            }
+            dest[pos++] = '\\';
+            dest[pos++] = 't';
+            break;
+        default:
+            dest[pos++] = c;
+            break;
+        }
+    }
+    dest[pos] = '\0';
+}
+
+static esp_err_t send_initial_data_script(httpd_req_t *req)
+{
+    const char *ssid = admin_portal_state_get_ssid(&g_state);
+    bool has_password = admin_portal_state_has_password(&g_state);
+    bool authorized = admin_portal_state_session_authorized(&g_state);
+
+    char escaped_ssid[128];
+    escape_js_string(escaped_ssid, sizeof(escaped_ssid), ssid);
+
+    char script[512];
+    snprintf(script, sizeof(script),
+             "window.TAPGATE_INITIAL_DATA={ap_ssid:\"%s\",has_password:%s,authorized:%s};",
+             escaped_ssid,
+             has_password ? "true" : "false",
+             authorized ? "true" : "false");
+
+    httpd_resp_set_type(req, "application/javascript");
+    set_no_cache_headers(req);
+    return httpd_resp_send(req, script, HTTPD_RESP_USE_STRLEN);
+}
+
+static esp_err_t send_json(httpd_req_t *req, const char *json)
+{
+    httpd_resp_set_type(req, "application/json");
+    set_no_cache_headers(req);
+    return httpd_resp_send(req, json, HTTPD_RESP_USE_STRLEN);
+}
+
+static esp_err_t send_busy_response(httpd_req_t *req)
+{
+    return send_json(req, "{\"status\":\"busy\",\"redirect\":\"/busy/\"}");
+}
+
+static esp_err_t send_expired_response(httpd_req_t *req)
+{
+    clear_session_cookie(req);
+    return send_json(req, "{\"status\":\"expired\",\"redirect\":\"/off/\"}");
+}
+
+static esp_err_t read_request_body(httpd_req_t *req, char *buffer, size_t buffer_len)
+{
+    if (!buffer || buffer_len == 0)
+        return ESP_ERR_INVALID_ARG;
+
+    if (req->content_len >= buffer_len)
+        return ESP_ERR_INVALID_SIZE;
+
+    size_t remaining = req->content_len;
+    size_t received = 0;
+    while (remaining > 0)
+    {
+        int ret = httpd_req_recv(req, buffer + received, remaining);
+        if (ret <= 0)
+        {
+            return ESP_FAIL;
+        }
+        received += (size_t)ret;
+        remaining -= (size_t)ret;
+    }
+    buffer[received] = '\0';
+    return ESP_OK;
+}
+
+static int hex_value(int c)
+{
+    if (c >= '0' && c <= '9')
+        return c - '0';
+    if (c >= 'a' && c <= 'f')
+        return 10 + (c - 'a');
+    if (c >= 'A' && c <= 'F')
+        return 10 + (c - 'A');
+    return -1;
+}
+
+static size_t url_decode(char *dest, size_t dest_len, const char *src)
+{
+    if (!dest || dest_len == 0)
+        return 0;
+    size_t pos = 0;
+    while (*src && pos + 1 < dest_len)
+    {
+        char c = *src++;
+        if (c == '+')
+        {
+            dest[pos++] = ' ';
+        }
+        else if (c == '%' && src[0] && src[1])
+        {
+            int hi = hex_value((unsigned char)src[0]);
+            int lo = hex_value((unsigned char)src[1]);
+            if (hi >= 0 && lo >= 0)
+            {
+                dest[pos++] = (char)((hi << 4) | lo);
+                src += 2;
+            }
+        }
+        else
+        {
+            dest[pos++] = c;
+        }
+    }
+    dest[pos] = '\0';
+    return pos;
+}
+
+static bool form_get_value(const char *body, const char *key, char *out, size_t out_len)
+{
+    if (!body || !key || !out || out_len == 0)
+        return false;
+
+    size_t key_len = strlen(key);
+    const char *cursor = body;
+    while (*cursor)
+    {
+        const char *eq = strchr(cursor, '=');
+        if (!eq)
+            break;
+        size_t name_len = (size_t)(eq - cursor);
+        const char *value_start = eq + 1;
+        const char *amp = strchr(value_start, '&');
+        size_t value_len = amp ? (size_t)(amp - value_start) : strlen(value_start);
+
+        if (name_len == key_len && strncmp(cursor, key, key_len) == 0)
+        {
+            char temp[256];
+            size_t copy_len = value_len < sizeof(temp) - 1 ? value_len : sizeof(temp) - 1;
+            memcpy(temp, value_start, copy_len);
+            temp[copy_len] = '\0';
+            url_decode(out, out_len, temp);
+            return true;
+        }
+
+        if (!amp)
+            break;
+        cursor = amp + 1;
+    }
+
+    return false;
+}
+
+static bool validate_ssid(const char *ssid)
+{
+    if (!ssid)
+        return false;
+    size_t len = strlen(ssid);
+    if (len == 0 || len >= MAX_SSID_SIZE)
+        return false;
+    return true;
+}
+
+static esp_err_t send_ok_redirect(httpd_req_t *req, const char *redirect)
+{
+    char payload[128];
+    snprintf(payload, sizeof(payload),
+             "{\"status\":\"ok\",\"redirect\":\"%s\"}", redirect);
+    return send_json(req, payload);
+}
+
+static esp_err_t send_error_code(httpd_req_t *req, const char *code)
+{
+    char payload[128];
+    snprintf(payload, sizeof(payload),
+             "{\"status\":\"error\",\"code\":\"%s\"}", code);
+    return send_json(req, payload);
+}
+
+static esp_err_t handle_initial_data(httpd_req_t *req)
+{
+    return send_initial_data_script(req);
+}
+
+static esp_err_t handle_session_info(httpd_req_t *req)
+{
+    char token[ADMIN_PORTAL_SESSION_TOKEN_LENGTH + 1] = {0};
+    bool has_token = get_session_token(req, token, sizeof(token));
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&g_state, has_token ? token : NULL, current_time_ms());
+
+    if (status == ADMIN_PORTAL_SESSION_BUSY)
+        return send_busy_response(req);
+    if (status == ADMIN_PORTAL_SESSION_EXPIRED)
+        return send_expired_response(req);
+
+    admin_portal_page_t resolved =
+        admin_portal_state_resolve_page(&g_state, ADMIN_PORTAL_PAGE_MAIN, status);
+    bool has_password = admin_portal_state_has_password(&g_state);
+    bool authorized = admin_portal_state_session_authorized(&g_state);
+
+    char escaped_ssid[128];
+    escape_js_string(escaped_ssid, sizeof(escaped_ssid), admin_portal_state_get_ssid(&g_state));
+
+    char payload[256];
+    const char *redirect = NULL;
+    if (!has_password)
+        redirect = "/enroll/";
+    else if (!authorized)
+        redirect = "/auth/";
+    else if (resolved != ADMIN_PORTAL_PAGE_MAIN)
+        redirect = "/main/";
+
+    if (redirect)
+    {
+        snprintf(payload, sizeof(payload),
+                 "{\"status\":\"redirect\",\"redirect\":\"%s\",\"ap_ssid\":\"%s\",\"authorized\":%s,\"has_password\":%s}",
+                 redirect,
+                 escaped_ssid,
+                 authorized ? "true" : "false",
+                 has_password ? "true" : "false");
+    }
+    else
+    {
+        snprintf(payload, sizeof(payload),
+                 "{\"status\":\"ok\",\"ap_ssid\":\"%s\",\"authorized\":%s,\"has_password\":%s}",
+                 escaped_ssid,
+                 authorized ? "true" : "false",
+                 has_password ? "true" : "false");
+    }
+
+    return send_json(req, payload);
+}
+
+static esp_err_t ensure_session(httpd_req_t *req)
+{
+    if (admin_portal_state_session_active(&g_state))
+        return ESP_OK;
+
+    char token[ADMIN_PORTAL_SESSION_TOKEN_LENGTH + 1];
+    generate_session_token(token, sizeof(token));
+    admin_portal_state_start_session(&g_state, token, current_time_ms(), false);
+    set_session_cookie(req, token);
+    return ESP_OK;
+}
+
+static esp_err_t ensure_session_for_request(httpd_req_t *req,
+                                            admin_portal_session_status_t status,
+                                            bool has_token)
+{
+    if (status == ADMIN_PORTAL_SESSION_MATCH)
+        return ESP_OK;
+
+    if (!has_token && admin_portal_state_session_active(&g_state) &&
+        admin_portal_state_has_password(&g_state))
+    {
+        return ESP_FAIL;
+    }
+
+    if (status == ADMIN_PORTAL_SESSION_NONE && !admin_portal_state_session_active(&g_state))
+        return ensure_session(req);
+
+    return ESP_OK;
+}
+
+static bool single_client_lockout(bool has_token)
+{
+    return (!has_token && admin_portal_state_session_active(&g_state) &&
+            admin_portal_state_has_password(&g_state));
+}
+
+static esp_err_t handle_page_request(httpd_req_t *req)
+{
+    const admin_portal_page_descriptor_t *requested =
+        (const admin_portal_page_descriptor_t *)req->user_ctx;
+    if (!requested)
+    {
+        httpd_resp_send_err(req, HTTPD_404_NOT_FOUND, "Not Found");
+        return ESP_FAIL;
+    }
+
+    char token[ADMIN_PORTAL_SESSION_TOKEN_LENGTH + 1] = {0};
+    bool has_token = get_session_token(req, token, sizeof(token));
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&g_state, has_token ? token : NULL, current_time_ms());
+
+    if (status == ADMIN_PORTAL_SESSION_BUSY)
+        return send_page_response(req, find_page_by_type(ADMIN_PORTAL_PAGE_BUSY));
+    if (status == ADMIN_PORTAL_SESSION_EXPIRED)
+        return send_page_response(req, find_page_by_type(ADMIN_PORTAL_PAGE_OFF));
+
+    if (ensure_session_for_request(req, status, has_token) != ESP_OK)
+    {
+        return send_page_response(req, find_page_by_type(ADMIN_PORTAL_PAGE_BUSY));
+    }
+
+    admin_portal_page_t resolved_page =
+        admin_portal_state_resolve_page(&g_state, requested->page, status);
+    const admin_portal_page_descriptor_t *resolved = find_page_by_type(resolved_page);
+    if (!resolved)
+    {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Page not available");
+        return ESP_FAIL;
+    }
+
+    if (resolved != requested)
+    {
+        httpd_resp_set_status(req, "302 Found");
+        httpd_resp_set_hdr(req, "Location", resolved->uri);
+        set_no_cache_headers(req);
+        return httpd_resp_send(req, NULL, 0);
+    }
+
+    if (status == ADMIN_PORTAL_SESSION_NONE && resolved->page != ADMIN_PORTAL_PAGE_BUSY &&
+        resolved->page != ADMIN_PORTAL_PAGE_OFF)
+    {
+        ensure_session(req);
+    }
+
+    return send_page_response(req, resolved);
+}
+
+static esp_err_t handle_root(httpd_req_t *req)
+{
+    req->user_ctx = (void *)find_page_by_type(ADMIN_PORTAL_PAGE_MAIN);
+    return handle_page_request(req);
+}
+
+static bool ensure_content_type_form(httpd_req_t *req)
+{
+    char content_type[32];
+    if (httpd_req_get_hdr_value_str(req, "Content-Type", content_type, sizeof(content_type)) != ESP_OK)
+        return false;
+    return strstr(content_type, "application/x-www-form-urlencoded") != NULL;
+}
+
+static esp_err_t handle_enroll(httpd_req_t *req)
+{
+    if (admin_portal_state_has_password(&g_state))
+        return send_json(req, "{\"status\":\"redirect\",\"redirect\":\"/auth/\"}");
+
+    char token[ADMIN_PORTAL_SESSION_TOKEN_LENGTH + 1] = {0};
+    bool has_token = get_session_token(req, token, sizeof(token));
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&g_state, has_token ? token : NULL, current_time_ms());
+
+    if (status == ADMIN_PORTAL_SESSION_BUSY)
+        return send_busy_response(req);
+    if (status == ADMIN_PORTAL_SESSION_EXPIRED)
+        return send_expired_response(req);
+    if (single_client_lockout(has_token))
+        return send_busy_response(req);
+
+    if (!ensure_content_type_form(req))
+        return send_error_code(req, "invalid_request");
+
+    char body[256];
+    if (read_request_body(req, body, sizeof(body)) != ESP_OK)
+        return send_error_code(req, "invalid_request");
+
+    char password[MAX_PASSWORD_SIZE] = {0};
+    char portal[MAX_SSID_SIZE] = {0};
+    form_get_value(body, "password", password, sizeof(password));
+    form_get_value(body, "portal", portal, sizeof(portal));
+
+    if (!admin_portal_state_password_valid(&g_state, password))
+        return send_error_code(req, "invalid_password");
+    if (!validate_ssid(portal))
+        return send_error_code(req, "invalid_ssid");
+
+    if (admin_portal_device_save_password(&g_state, password) != ESP_OK)
+        return send_error_code(req, "storage_failed");
+    if (admin_portal_device_save_ssid(&g_state, portal) != ESP_OK)
+        return send_error_code(req, "storage_failed");
+
+    if (!admin_portal_state_session_active(&g_state))
+        ensure_session(req);
+    admin_portal_state_authorize_session(&g_state);
+    return send_ok_redirect(req, "/main/");
+}
+
+static esp_err_t handle_login(httpd_req_t *req)
+{
+    if (!admin_portal_state_has_password(&g_state))
+        return send_json(req, "{\"status\":\"redirect\",\"redirect\":\"/enroll/\"}");
+
+    char token[ADMIN_PORTAL_SESSION_TOKEN_LENGTH + 1] = {0};
+    bool has_token = get_session_token(req, token, sizeof(token));
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&g_state, has_token ? token : NULL, current_time_ms());
+
+    if (status == ADMIN_PORTAL_SESSION_BUSY)
+        return send_busy_response(req);
+    if (status == ADMIN_PORTAL_SESSION_EXPIRED)
+        return send_expired_response(req);
+    if (single_client_lockout(has_token))
+        return send_busy_response(req);
+
+    if (!ensure_content_type_form(req))
+        return send_error_code(req, "invalid_request");
+
+    char body[128];
+    if (read_request_body(req, body, sizeof(body)) != ESP_OK)
+        return send_error_code(req, "invalid_request");
+
+    char password[MAX_PASSWORD_SIZE] = {0};
+    form_get_value(body, "password", password, sizeof(password));
+
+    if (!admin_portal_state_verify_password(&g_state, password))
+        return send_error_code(req, "wrong_password");
+
+    if (!admin_portal_state_session_active(&g_state))
+        ensure_session(req);
+    admin_portal_state_authorize_session(&g_state);
+    return send_ok_redirect(req, "/main/");
+}
+
+static esp_err_t handle_change_password(httpd_req_t *req)
+{
+    char token[ADMIN_PORTAL_SESSION_TOKEN_LENGTH + 1] = {0};
+    bool has_token = get_session_token(req, token, sizeof(token));
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&g_state, has_token ? token : NULL, current_time_ms());
+
+    if (status == ADMIN_PORTAL_SESSION_BUSY)
+        return send_busy_response(req);
+    if (status == ADMIN_PORTAL_SESSION_EXPIRED)
+        return send_expired_response(req);
+    if (single_client_lockout(has_token))
+        return send_busy_response(req);
+
+    if (!admin_portal_state_session_authorized(&g_state))
+        return send_json(req, "{\"status\":\"redirect\",\"redirect\":\"/auth/\"}");
+
+    if (!ensure_content_type_form(req))
+        return send_error_code(req, "invalid_request");
+
+    char body[256];
+    if (read_request_body(req, body, sizeof(body)) != ESP_OK)
+        return send_error_code(req, "invalid_request");
+
+    char current[MAX_PASSWORD_SIZE] = {0};
+    char next[MAX_PASSWORD_SIZE] = {0};
+    form_get_value(body, "current", current, sizeof(current));
+    form_get_value(body, "next", next, sizeof(next));
+
+    if (!admin_portal_state_verify_password(&g_state, current))
+        return send_error_code(req, "wrong_password");
+    if (!admin_portal_state_password_valid(&g_state, next))
+        return send_error_code(req, "invalid_new_password");
+
+    if (admin_portal_device_save_password(&g_state, next) != ESP_OK)
+        return send_error_code(req, "storage_failed");
+
+    return send_ok_redirect(req, "/device/");
+}
+
+static esp_err_t handle_update_device(httpd_req_t *req)
+{
+    char token[ADMIN_PORTAL_SESSION_TOKEN_LENGTH + 1] = {0};
+    bool has_token = get_session_token(req, token, sizeof(token));
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&g_state, has_token ? token : NULL, current_time_ms());
+
+    if (status == ADMIN_PORTAL_SESSION_BUSY)
+        return send_busy_response(req);
+    if (status == ADMIN_PORTAL_SESSION_EXPIRED)
+        return send_expired_response(req);
+    if (single_client_lockout(has_token))
+        return send_busy_response(req);
+
+    if (!admin_portal_state_session_authorized(&g_state))
+        return send_json(req, "{\"status\":\"redirect\",\"redirect\":\"/auth/\"}");
+
+    if (!ensure_content_type_form(req))
+        return send_error_code(req, "invalid_request");
+
+    char body[256];
+    if (read_request_body(req, body, sizeof(body)) != ESP_OK)
+        return send_error_code(req, "invalid_request");
+
+    char ssid[MAX_SSID_SIZE] = {0};
+    form_get_value(body, "ssid", ssid, sizeof(ssid));
+    if (!validate_ssid(ssid))
+        return send_error_code(req, "invalid_ssid");
+
+    if (admin_portal_device_save_ssid(&g_state, ssid) != ESP_OK)
+        return send_error_code(req, "storage_failed");
+
+    return send_ok_redirect(req, "/main/");
+}
+
+esp_err_t admin_portal_http_service_start(httpd_handle_t server)
+{
+    if (!server)
+        return ESP_ERR_INVALID_ARG;
+    if (g_service_started)
+        return ESP_OK;
+
+    admin_portal_state_init(&g_state,
+                            ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN * 60U * 1000U,
+                            WPA2_MINIMUM_PASSWORD_LENGTH);
+    admin_portal_device_load(&g_state);
+
+    esp_err_t err;
+
+    for (size_t i = 0; i < sizeof(g_assets) / sizeof(g_assets[0]); ++i)
+    {
+        httpd_uri_t asset_uri = {
+            .uri = g_assets[i].path,
+            .method = HTTP_GET,
+            .handler = handle_asset,
+            .user_ctx = (void *)&g_assets[i],
+        };
+        err = httpd_register_uri_handler(server, &asset_uri);
+        if (err != ESP_OK)
+        {
+            LOGE(TAG, "Failed to register asset %s: %s", g_assets[i].path, esp_err_to_name(err));
+            return err;
+        }
+    }
+
+    for (size_t i = 0; i < sizeof(g_pages) / sizeof(g_pages[0]); ++i)
+    {
+        httpd_uri_t page_uri = {
+            .uri = g_pages[i]->uri,
+            .method = HTTP_GET,
+            .handler = handle_page_request,
+            .user_ctx = (void *)g_pages[i],
+        };
+        err = httpd_register_uri_handler(server, &page_uri);
+        if (err != ESP_OK)
+        {
+            LOGE(TAG, "Failed to register page %s: %s", g_pages[i]->uri, esp_err_to_name(err));
+            return err;
+        }
+    }
+
+    httpd_uri_t root_uri = {
+        .uri = "/",
+        .method = HTTP_GET,
+        .handler = handle_root,
+    };
+    err = httpd_register_uri_handler(server, &root_uri);
+    if (err != ESP_OK)
+    {
+        LOGE(TAG, "Failed to register root handler: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    httpd_uri_t initial_data_uri = {
+        .uri = "/api/initial-data.js",
+        .method = HTTP_GET,
+        .handler = handle_initial_data,
+    };
+    err = httpd_register_uri_handler(server, &initial_data_uri);
+    if (err != ESP_OK)
+        return err;
+
+    httpd_uri_t session_uri = {
+        .uri = "/api/session",
+        .method = HTTP_GET,
+        .handler = handle_session_info,
+    };
+    err = httpd_register_uri_handler(server, &session_uri);
+    if (err != ESP_OK)
+        return err;
+
+    httpd_uri_t enroll_uri = {
+        .uri = "/api/enroll",
+        .method = HTTP_POST,
+        .handler = handle_enroll,
+    };
+    err = httpd_register_uri_handler(server, &enroll_uri);
+    if (err != ESP_OK)
+        return err;
+
+    httpd_uri_t login_uri = {
+        .uri = "/api/login",
+        .method = HTTP_POST,
+        .handler = handle_login,
+    };
+    err = httpd_register_uri_handler(server, &login_uri);
+    if (err != ESP_OK)
+        return err;
+
+    httpd_uri_t change_psw_uri = {
+        .uri = "/api/change-password",
+        .method = HTTP_POST,
+        .handler = handle_change_password,
+    };
+    err = httpd_register_uri_handler(server, &change_psw_uri);
+    if (err != ESP_OK)
+        return err;
+
+    httpd_uri_t device_uri = {
+        .uri = "/api/device",
+        .method = HTTP_POST,
+        .handler = handle_update_device,
+    };
+    err = httpd_register_uri_handler(server, &device_uri);
+    if (err != ESP_OK)
+        return err;
+
+    g_server = server;
+    g_service_started = true;
+    LOGI(TAG, "Admin portal HTTP service started");
+    return ESP_OK;
+}
+
+void admin_portal_http_service_stop(void)
+{
+    if (!g_service_started || !g_server)
+        return;
+    g_service_started = false;
+    g_server = NULL;
+    memset(&g_state.session, 0, sizeof(g_state.session));
+}

--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -155,6 +155,8 @@ static const admin_portal_page_descriptor_t *g_pages[ADMIN_PORTAL_PAGE_COUNT];
 static char g_page_trimmed_uris[ADMIN_PORTAL_PAGE_COUNT][64];
 static bool g_page_trimmed_uris_valid[ADMIN_PORTAL_PAGE_COUNT];
 
+static size_t trim_trailing_slashes(const char *uri, size_t len);
+
 static void ensure_assets_initialized(void)
 {
     for (size_t i = 0; i < sizeof(g_assets) / sizeof(g_assets[0]); ++i)
@@ -935,8 +937,10 @@ esp_err_t admin_portal_http_service_start(httpd_handle_t server)
             httpd_uri_t alt_uri = page_uri;
             alt_uri.uri = g_page_trimmed_uris[i];
             err = httpd_register_uri_handler(server, &alt_uri);
+#ifdef ESP_ERR_HTTPD_URI_ALREADY_REGISTERED
             if (err == ESP_ERR_HTTPD_URI_ALREADY_REGISTERED)
                 err = ESP_OK;
+#endif
             if (err != ESP_OK)
             {
                 LOGE(TAG, "Failed to register alt page %s: %s", alt_uri.uri, esp_err_to_name(err));

--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -703,7 +703,14 @@ static esp_err_t handle_time_probe(httpd_req_t *req)
 
 static bool ensure_content_type_form(httpd_req_t *req)
 {
-    char content_type[32];
+    size_t len = httpd_req_get_hdr_value_len(req, "Content-Type");
+    if (len == 0)
+        return false;
+
+    char content_type[96];
+    if (len >= sizeof(content_type))
+        return false;
+
     if (httpd_req_get_hdr_value_str(req, "Content-Type", content_type, sizeof(content_type)) != ESP_OK)
         return false;
     return strstr(content_type, "application/x-www-form-urlencoded") != NULL;

--- a/esp32_mcu/components/admin_portal/http_service.h
+++ b/esp32_mcu/components/admin_portal/http_service.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "esp_err.h"
+#include "esp_http_server.h"
+
+esp_err_t admin_portal_http_service_start(httpd_handle_t server);
+void admin_portal_http_service_stop(void);

--- a/esp32_mcu/components/admin_portal/pages/page_auth.c
+++ b/esp32_mcu/components/admin_portal/pages/page_auth.c
@@ -1,0 +1,18 @@
+#include "page_auth.h"
+
+extern const uint8_t _binary_page_auth_html_gz_start[];
+extern const uint8_t _binary_page_auth_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/auth/",
+    .page = ADMIN_PORTAL_PAGE_AUTH,
+    .data = _binary_page_auth_html_gz_start,
+    .size = (size_t)(_binary_page_auth_html_gz_end - _binary_page_auth_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_auth_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_auth.c
+++ b/esp32_mcu/components/admin_portal/pages/page_auth.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_auth_html_gz_start[];
 extern const uint8_t _binary_page_auth_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/auth/",
     .page = ADMIN_PORTAL_PAGE_AUTH,
     .data = _binary_page_auth_html_gz_start,
-    .size = (size_t)(_binary_page_auth_html_gz_end - _binary_page_auth_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_auth_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_auth_html_gz_end - _binary_page_auth_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_auth.h
+++ b/esp32_mcu/components/admin_portal/pages/page_auth.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_auth_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_busy.c
+++ b/esp32_mcu/components/admin_portal/pages/page_busy.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_busy_html_gz_start[];
 extern const uint8_t _binary_page_busy_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/busy/",
     .page = ADMIN_PORTAL_PAGE_BUSY,
     .data = _binary_page_busy_html_gz_start,
-    .size = (size_t)(_binary_page_busy_html_gz_end - _binary_page_busy_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_busy_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_busy_html_gz_end - _binary_page_busy_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_busy.c
+++ b/esp32_mcu/components/admin_portal/pages/page_busy.c
@@ -1,0 +1,18 @@
+#include "page_busy.h"
+
+extern const uint8_t _binary_page_busy_html_gz_start[];
+extern const uint8_t _binary_page_busy_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/busy/",
+    .page = ADMIN_PORTAL_PAGE_BUSY,
+    .data = _binary_page_busy_html_gz_start,
+    .size = (size_t)(_binary_page_busy_html_gz_end - _binary_page_busy_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_busy_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_busy.h
+++ b/esp32_mcu/components/admin_portal/pages/page_busy.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_busy_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_change_psw.c
+++ b/esp32_mcu/components/admin_portal/pages/page_change_psw.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_change_psw_html_gz_start[];
 extern const uint8_t _binary_page_change_psw_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/psw/",
     .page = ADMIN_PORTAL_PAGE_CHANGE_PASSWORD,
     .data = _binary_page_change_psw_html_gz_start,
-    .size = (size_t)(_binary_page_change_psw_html_gz_end - _binary_page_change_psw_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_change_psw_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_change_psw_html_gz_end - _binary_page_change_psw_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_change_psw.c
+++ b/esp32_mcu/components/admin_portal/pages/page_change_psw.c
@@ -1,0 +1,18 @@
+#include "page_change_psw.h"
+
+extern const uint8_t _binary_page_change_psw_html_gz_start[];
+extern const uint8_t _binary_page_change_psw_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/psw/",
+    .page = ADMIN_PORTAL_PAGE_CHANGE_PASSWORD,
+    .data = _binary_page_change_psw_html_gz_start,
+    .size = (size_t)(_binary_page_change_psw_html_gz_end - _binary_page_change_psw_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_change_psw_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_change_psw.h
+++ b/esp32_mcu/components/admin_portal/pages/page_change_psw.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_change_psw_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_clients.c
+++ b/esp32_mcu/components/admin_portal/pages/page_clients.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_clients_html_gz_start[];
 extern const uint8_t _binary_page_clients_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/clients/",
     .page = ADMIN_PORTAL_PAGE_CLIENTS,
     .data = _binary_page_clients_html_gz_start,
-    .size = (size_t)(_binary_page_clients_html_gz_end - _binary_page_clients_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_clients_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_clients_html_gz_end - _binary_page_clients_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_clients.c
+++ b/esp32_mcu/components/admin_portal/pages/page_clients.c
@@ -1,0 +1,18 @@
+#include "page_clients.h"
+
+extern const uint8_t _binary_page_clients_html_gz_start[];
+extern const uint8_t _binary_page_clients_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/clients/",
+    .page = ADMIN_PORTAL_PAGE_CLIENTS,
+    .data = _binary_page_clients_html_gz_start,
+    .size = (size_t)(_binary_page_clients_html_gz_end - _binary_page_clients_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_clients_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_clients.h
+++ b/esp32_mcu/components/admin_portal/pages/page_clients.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_clients_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_descriptor.h
+++ b/esp32_mcu/components/admin_portal/pages/page_descriptor.h
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "admin_portal_state.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct {
+    const char *uri;
+    admin_portal_page_t page;
+    const uint8_t *data;
+    size_t size;
+    const char *content_type;
+    bool compressed;
+} admin_portal_page_descriptor_t;
+
+const admin_portal_page_descriptor_t *admin_portal_page_auth_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_busy_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_change_psw_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_clients_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_device_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_enroll_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_events_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_main_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_off_descriptor(void);
+const admin_portal_page_descriptor_t *admin_portal_page_wifi_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_device.c
+++ b/esp32_mcu/components/admin_portal/pages/page_device.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_device_html_gz_start[];
 extern const uint8_t _binary_page_device_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/device/",
     .page = ADMIN_PORTAL_PAGE_DEVICE,
     .data = _binary_page_device_html_gz_start,
-    .size = (size_t)(_binary_page_device_html_gz_end - _binary_page_device_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_device_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_device_html_gz_end - _binary_page_device_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_device.c
+++ b/esp32_mcu/components/admin_portal/pages/page_device.c
@@ -1,0 +1,18 @@
+#include "page_device.h"
+
+extern const uint8_t _binary_page_device_html_gz_start[];
+extern const uint8_t _binary_page_device_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/device/",
+    .page = ADMIN_PORTAL_PAGE_DEVICE,
+    .data = _binary_page_device_html_gz_start,
+    .size = (size_t)(_binary_page_device_html_gz_end - _binary_page_device_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_device_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_device.h
+++ b/esp32_mcu/components/admin_portal/pages/page_device.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_device_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_enroll.c
+++ b/esp32_mcu/components/admin_portal/pages/page_enroll.c
@@ -1,0 +1,18 @@
+#include "page_enroll.h"
+
+extern const uint8_t _binary_page_enroll_html_gz_start[];
+extern const uint8_t _binary_page_enroll_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/enroll/",
+    .page = ADMIN_PORTAL_PAGE_ENROLL,
+    .data = _binary_page_enroll_html_gz_start,
+    .size = (size_t)(_binary_page_enroll_html_gz_end - _binary_page_enroll_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_enroll_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_enroll.c
+++ b/esp32_mcu/components/admin_portal/pages/page_enroll.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_enroll_html_gz_start[];
 extern const uint8_t _binary_page_enroll_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/enroll/",
     .page = ADMIN_PORTAL_PAGE_ENROLL,
     .data = _binary_page_enroll_html_gz_start,
-    .size = (size_t)(_binary_page_enroll_html_gz_end - _binary_page_enroll_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_enroll_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_enroll_html_gz_end - _binary_page_enroll_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_enroll.h
+++ b/esp32_mcu/components/admin_portal/pages/page_enroll.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_enroll_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_events.c
+++ b/esp32_mcu/components/admin_portal/pages/page_events.c
@@ -1,0 +1,18 @@
+#include "page_events.h"
+
+extern const uint8_t _binary_page_events_html_gz_start[];
+extern const uint8_t _binary_page_events_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/events/",
+    .page = ADMIN_PORTAL_PAGE_EVENTS,
+    .data = _binary_page_events_html_gz_start,
+    .size = (size_t)(_binary_page_events_html_gz_end - _binary_page_events_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_events_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_events.c
+++ b/esp32_mcu/components/admin_portal/pages/page_events.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_events_html_gz_start[];
 extern const uint8_t _binary_page_events_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/events/",
     .page = ADMIN_PORTAL_PAGE_EVENTS,
     .data = _binary_page_events_html_gz_start,
-    .size = (size_t)(_binary_page_events_html_gz_end - _binary_page_events_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_events_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_events_html_gz_end - _binary_page_events_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_events.h
+++ b/esp32_mcu/components/admin_portal/pages/page_events.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_events_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_main.c
+++ b/esp32_mcu/components/admin_portal/pages/page_main.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_main_html_gz_start[];
 extern const uint8_t _binary_page_main_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/main/",
     .page = ADMIN_PORTAL_PAGE_MAIN,
     .data = _binary_page_main_html_gz_start,
-    .size = (size_t)(_binary_page_main_html_gz_end - _binary_page_main_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_main_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_main_html_gz_end - _binary_page_main_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_main.c
+++ b/esp32_mcu/components/admin_portal/pages/page_main.c
@@ -1,0 +1,18 @@
+#include "page_main.h"
+
+extern const uint8_t _binary_page_main_html_gz_start[];
+extern const uint8_t _binary_page_main_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/main/",
+    .page = ADMIN_PORTAL_PAGE_MAIN,
+    .data = _binary_page_main_html_gz_start,
+    .size = (size_t)(_binary_page_main_html_gz_end - _binary_page_main_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_main_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_main.h
+++ b/esp32_mcu/components/admin_portal/pages/page_main.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_main_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_off.c
+++ b/esp32_mcu/components/admin_portal/pages/page_off.c
@@ -1,0 +1,18 @@
+#include "page_off.h"
+
+extern const uint8_t _binary_page_off_html_gz_start[];
+extern const uint8_t _binary_page_off_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/off/",
+    .page = ADMIN_PORTAL_PAGE_OFF,
+    .data = _binary_page_off_html_gz_start,
+    .size = (size_t)(_binary_page_off_html_gz_end - _binary_page_off_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_off_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_off.c
+++ b/esp32_mcu/components/admin_portal/pages/page_off.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_off_html_gz_start[];
 extern const uint8_t _binary_page_off_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/off/",
     .page = ADMIN_PORTAL_PAGE_OFF,
     .data = _binary_page_off_html_gz_start,
-    .size = (size_t)(_binary_page_off_html_gz_end - _binary_page_off_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_off_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_off_html_gz_end - _binary_page_off_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_off.h
+++ b/esp32_mcu/components/admin_portal/pages/page_off.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_off_descriptor(void);

--- a/esp32_mcu/components/admin_portal/pages/page_wifi.c
+++ b/esp32_mcu/components/admin_portal/pages/page_wifi.c
@@ -1,0 +1,18 @@
+#include "page_wifi.h"
+
+extern const uint8_t _binary_page_wifi_html_gz_start[];
+extern const uint8_t _binary_page_wifi_html_gz_end[];
+
+static const admin_portal_page_descriptor_t descriptor = {
+    .uri = "/wifi/",
+    .page = ADMIN_PORTAL_PAGE_WIFI,
+    .data = _binary_page_wifi_html_gz_start,
+    .size = (size_t)(_binary_page_wifi_html_gz_end - _binary_page_wifi_html_gz_start),
+    .content_type = "text/html",
+    .compressed = true,
+};
+
+const admin_portal_page_descriptor_t *admin_portal_page_wifi_descriptor(void)
+{
+    return &descriptor;
+}

--- a/esp32_mcu/components/admin_portal/pages/page_wifi.c
+++ b/esp32_mcu/components/admin_portal/pages/page_wifi.c
@@ -3,16 +3,18 @@
 extern const uint8_t _binary_page_wifi_html_gz_start[];
 extern const uint8_t _binary_page_wifi_html_gz_end[];
 
-static const admin_portal_page_descriptor_t descriptor = {
+static admin_portal_page_descriptor_t descriptor = {
     .uri = "/wifi/",
     .page = ADMIN_PORTAL_PAGE_WIFI,
     .data = _binary_page_wifi_html_gz_start,
-    .size = (size_t)(_binary_page_wifi_html_gz_end - _binary_page_wifi_html_gz_start),
+    .size = 0,
     .content_type = "text/html",
     .compressed = true,
 };
 
 const admin_portal_page_descriptor_t *admin_portal_page_wifi_descriptor(void)
 {
+    if (descriptor.size == 0)
+        descriptor.size = (size_t)(_binary_page_wifi_html_gz_end - _binary_page_wifi_html_gz_start);
     return &descriptor;
 }

--- a/esp32_mcu/components/admin_portal/pages/page_wifi.h
+++ b/esp32_mcu/components/admin_portal/pages/page_wifi.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "page_descriptor.h"
+
+const admin_portal_page_descriptor_t *admin_portal_page_wifi_descriptor(void);

--- a/esp32_mcu/components/admin_portal/test/mocks/mock_esp_http_server.h
+++ b/esp32_mcu/components/admin_portal/test/mocks/mock_esp_http_server.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "esp_err.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef void *httpd_handle_t;
+
+typedef struct httpd_req {
+    void *user_ctx;
+    size_t content_len;
+} httpd_req_t;
+
+typedef enum {
+    HTTP_GET = 0,
+    HTTP_POST = 1,
+} httpd_method_t;
+
+typedef struct httpd_uri {
+    const char *uri;
+    httpd_method_t method;
+    esp_err_t (*handler)(httpd_req_t *req);
+    void *user_ctx;
+    void *uri_match_fn;
+} httpd_uri_t;

--- a/esp32_mcu/components/admin_portal/test/mocks/mock_esp_timer.h
+++ b/esp32_mcu/components/admin_portal/test/mocks/mock_esp_timer.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdint.h>
+
+static inline int64_t esp_timer_get_time(void)
+{
+    return 0;
+}

--- a/esp32_mcu/components/admin_portal/test/mocks/mock_nvs.h
+++ b/esp32_mcu/components/admin_portal/test/mocks/mock_nvs.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "esp_err.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+static inline esp_err_t nvm_wifi_read_string(const char *key, char *buffer, size_t size)
+{
+    (void)key;
+    if (buffer && size)
+        buffer[0] = '\0';
+    return ESP_OK;
+}
+
+static inline esp_err_t nvm_wifi_write_string(const char *key, const char *value)
+{
+    (void)key;
+    (void)value;
+    return ESP_OK;
+}
+
+static inline esp_err_t nvm_wifi_read_u32(const char *key, uint32_t *value)
+{
+    (void)key;
+    if (value)
+        *value = 0;
+    return ESP_OK;
+}
+
+static inline esp_err_t nvm_wifi_write_u32(const char *key, uint32_t value)
+{
+    (void)key;
+    (void)value;
+    return ESP_OK;
+}

--- a/esp32_mcu/components/admin_portal/test/test_admin_portal.c
+++ b/esp32_mcu/components/admin_portal/test/test_admin_portal.c
@@ -1,0 +1,97 @@
+#include "unity.h"
+
+#include "admin_portal_device.h"
+#include "admin_portal_state.h"
+
+static admin_portal_state_t state;
+
+void setUp(void)
+{
+    admin_portal_state_init(&state, ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN * 60U * 1000U,
+                            WPA2_MINIMUM_PASSWORD_LENGTH);
+}
+
+void tearDown(void)
+{
+}
+
+static void set_password(const char *password)
+{
+    admin_portal_state_set_password(&state, password);
+}
+
+static void start_authorized_session(const char *token)
+{
+    admin_portal_state_start_session(&state, token, 0, false);
+    admin_portal_state_authorize_session(&state);
+}
+
+void test_enroll_required_when_password_missing(void)
+{
+    admin_portal_page_t page =
+        admin_portal_state_resolve_page(&state, ADMIN_PORTAL_PAGE_MAIN, ADMIN_PORTAL_SESSION_NONE);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_PAGE_ENROLL, page);
+}
+
+void test_auth_page_redirects_when_no_password(void)
+{
+    admin_portal_page_t page =
+        admin_portal_state_resolve_page(&state, ADMIN_PORTAL_PAGE_AUTH, ADMIN_PORTAL_SESSION_NONE);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_PAGE_ENROLL, page);
+}
+
+void test_auth_required_when_password_set(void)
+{
+    set_password("strongpass");
+    admin_portal_page_t page =
+        admin_portal_state_resolve_page(&state, ADMIN_PORTAL_PAGE_MAIN, ADMIN_PORTAL_SESSION_NONE);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_PAGE_AUTH, page);
+}
+
+void test_main_allowed_after_authorization(void)
+{
+    set_password("strongpass");
+    start_authorized_session("token");
+    admin_portal_page_t page =
+        admin_portal_state_resolve_page(&state, ADMIN_PORTAL_PAGE_MAIN, ADMIN_PORTAL_SESSION_MATCH);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_PAGE_MAIN, page);
+}
+
+void test_auth_redirects_back_to_main_when_authorized(void)
+{
+    set_password("strongpass");
+    start_authorized_session("token");
+    admin_portal_page_t page =
+        admin_portal_state_resolve_page(&state, ADMIN_PORTAL_PAGE_AUTH, ADMIN_PORTAL_SESSION_MATCH);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_PAGE_MAIN, page);
+}
+
+void test_busy_page_returned_when_session_busy(void)
+{
+    set_password("strongpass");
+    admin_portal_session_status_t status = ADMIN_PORTAL_SESSION_BUSY;
+    admin_portal_page_t page =
+        admin_portal_state_resolve_page(&state, ADMIN_PORTAL_PAGE_MAIN, status);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_PAGE_BUSY, page);
+}
+
+void test_off_page_returned_when_expired(void)
+{
+    admin_portal_session_status_t status = ADMIN_PORTAL_SESSION_EXPIRED;
+    admin_portal_page_t page =
+        admin_portal_state_resolve_page(&state, ADMIN_PORTAL_PAGE_MAIN, status);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_PAGE_OFF, page);
+}
+
+int main(int argc, char **argv)
+{
+    UnityBegin(argv[0]);
+    RUN_TEST(test_enroll_required_when_password_missing);
+    RUN_TEST(test_auth_page_redirects_when_no_password);
+    RUN_TEST(test_auth_required_when_password_set);
+    RUN_TEST(test_main_allowed_after_authorization);
+    RUN_TEST(test_auth_redirects_back_to_main_when_authorized);
+    RUN_TEST(test_busy_page_returned_when_session_busy);
+    RUN_TEST(test_off_page_returned_when_expired);
+    return UnityEnd();
+}

--- a/esp32_mcu/components/admin_portal/test/test_session_mgmt.c
+++ b/esp32_mcu/components/admin_portal/test/test_session_mgmt.c
@@ -1,0 +1,67 @@
+#include "unity.h"
+
+#include "admin_portal_device.h"
+#include "admin_portal_state.h"
+
+static admin_portal_state_t state;
+
+void setUp(void)
+{
+    admin_portal_state_init(&state, ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN * 60U * 1000U,
+                            WPA2_MINIMUM_PASSWORD_LENGTH);
+}
+
+void tearDown(void)
+{
+}
+
+void test_session_starts_and_matches_token(void)
+{
+    admin_portal_state_start_session(&state, "abcdef", 1000, false);
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&state, "abcdef", 1000);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_SESSION_MATCH, status);
+}
+
+void test_session_busy_for_different_token_when_password_exists(void)
+{
+    admin_portal_state_set_password(&state, "strongpass");
+    admin_portal_state_start_session(&state, "token", 1000, true);
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&state, "other", 1100);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_SESSION_BUSY, status);
+}
+
+void test_session_not_busy_without_password(void)
+{
+    admin_portal_state_start_session(&state, "token", 0, false);
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&state, "other", 50);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_SESSION_NONE, status);
+}
+
+void test_session_expires_after_timeout(void)
+{
+    admin_portal_state_set_password(&state, "strongpass");
+    admin_portal_state_start_session(&state, "token", 0, true);
+    admin_portal_session_status_t status =
+        admin_portal_state_check_session(&state, "token", state.inactivity_timeout_ms + 1);
+    TEST_ASSERT_EQUAL_INT(ADMIN_PORTAL_SESSION_EXPIRED, status);
+}
+
+void test_password_validation_rules(void)
+{
+    TEST_ASSERT_FALSE(admin_portal_state_password_valid(&state, "short"));
+    TEST_ASSERT_TRUE(admin_portal_state_password_valid(&state, "longenough"));
+}
+
+int main(int argc, char **argv)
+{
+    UnityBegin(argv[0]);
+    RUN_TEST(test_session_starts_and_matches_token);
+    RUN_TEST(test_session_busy_for_different_token_when_password_exists);
+    RUN_TEST(test_session_not_busy_without_password);
+    RUN_TEST(test_session_expires_after_timeout);
+    RUN_TEST(test_password_validation_rules);
+    return UnityEnd();
+}

--- a/esp32_mcu/components/common/nvm/nvm.c
+++ b/esp32_mcu/components/common/nvm/nvm.c
@@ -9,6 +9,14 @@
 
 static const char *TAG_NVM = "NVM";
 
+#ifndef NVM_WIFI_PARTITION
+#define NVM_WIFI_PARTITION NVM_PARTITION_DEFAULT
+#endif
+
+#ifndef NVM_WIFI_NAMESPACE
+#define NVM_WIFI_NAMESPACE "wifimanager"
+#endif
+
 static esp_err_t ensure_partition_ready(const char *partition_label)
 {
     if (!partition_label)
@@ -149,4 +157,24 @@ esp_err_t nvm_write_u32(const char *partition,
         err = nvs_commit(handle);
     nvs_close(handle);
     return err;
+}
+
+esp_err_t nvm_wifi_read_string(const char *key, char *buffer, size_t size)
+{
+    return nvm_read_string(NVM_WIFI_PARTITION, NVM_WIFI_NAMESPACE, key, buffer, size);
+}
+
+esp_err_t nvm_wifi_write_string(const char *key, const char *value)
+{
+    return nvm_write_string(NVM_WIFI_PARTITION, NVM_WIFI_NAMESPACE, key, value);
+}
+
+esp_err_t nvm_wifi_read_u32(const char *key, uint32_t *value)
+{
+    return nvm_read_u32(NVM_WIFI_PARTITION, NVM_WIFI_NAMESPACE, key, value);
+}
+
+esp_err_t nvm_wifi_write_u32(const char *key, uint32_t value)
+{
+    return nvm_write_u32(NVM_WIFI_PARTITION, NVM_WIFI_NAMESPACE, key, value);
 }

--- a/esp32_mcu/components/common/nvm/nvm.h
+++ b/esp32_mcu/components/common/nvm/nvm.h
@@ -27,3 +27,9 @@ esp_err_t nvm_write_u32(const char *partition,
                         const char *namespace_name,
                         const char *key,
                         uint32_t value);
+
+// Convenience helpers operating on the Wi-Fi partition/namespace.
+esp_err_t nvm_wifi_read_string(const char *key, char *buffer, size_t size);
+esp_err_t nvm_wifi_write_string(const char *key, const char *value);
+esp_err_t nvm_wifi_read_u32(const char *key, uint32_t *value);
+esp_err_t nvm_wifi_write_u32(const char *key, uint32_t value);

--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -31,10 +31,12 @@ target_include_directories(unity
 
 # Interface library exposing ESP-IDF shims used when compiling production
 # sources on the host.
-add_library(tapgate_idf_mocks INTERFACE)
+add_library(tapgate_idf_mocks STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/nvs_mock.c
+)
 
 target_include_directories(tapgate_idf_mocks
-    INTERFACE
+    PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/mocks/include
 )
 
@@ -66,7 +68,8 @@ set(_tapgate_component_sources
     ${CMAKE_CURRENT_LIST_DIR}/../components/rsapem/rsapem.c
     ${CMAKE_CURRENT_LIST_DIR}/../components/clients/clients.c
     ${CMAKE_CURRENT_LIST_DIR}/../components/logs/logs.c
-    ${CMAKE_CURRENT_LIST_DIR}/../components/nvm/nvm.c
+    ${CMAKE_CURRENT_LIST_DIR}/../components/common/nvm/nvm.c
+    ${CMAKE_CURRENT_LIST_DIR}/../components/admin_portal/admin_portal_device.c
     ${CMAKE_CURRENT_LIST_DIR}/../components/admin_portal/admin_portal_state.c
 )
 
@@ -150,4 +153,5 @@ endfunction()
 tapgate_add_unity_test(test_types ${CMAKE_CURRENT_LIST_DIR}/test_types.c)
 tapgate_add_unity_test(test_logs ${CMAKE_CURRENT_LIST_DIR}/test_logs.c)
 tapgate_add_unity_test(test_admin_portal_state ${CMAKE_CURRENT_LIST_DIR}/test_admin_portal_state.c)
+tapgate_add_unity_test(test_admin_portal_device ${CMAKE_CURRENT_LIST_DIR}/test_admin_portal_device.c)
 

--- a/esp32_mcu/tests_host/mocks/include/esp_err.h
+++ b/esp32_mcu/tests_host/mocks/include/esp_err.h
@@ -16,6 +16,7 @@ typedef int32_t esp_err_t;
 #define ESP_ERR_INVALID_ARG 0x102
 #define ESP_ERR_NOT_FOUND   0x103
 #define ESP_ERR_TIMEOUT     0x104
+#define ESP_ERR_NVS_NOT_FOUND 0x105
 
 static inline const char *esp_err_to_name(esp_err_t code)
 {
@@ -33,6 +34,8 @@ static inline const char *esp_err_to_name(esp_err_t code)
             return "ESP_ERR_NOT_FOUND";
         case ESP_ERR_TIMEOUT:
             return "ESP_ERR_TIMEOUT";
+        case ESP_ERR_NVS_NOT_FOUND:
+            return "ESP_ERR_NVS_NOT_FOUND";
         default:
             return "ESP_ERR_UNKNOWN";
     }

--- a/esp32_mcu/tests_host/mocks/include/nvs.h
+++ b/esp32_mcu/tests_host/mocks/include/nvs.h
@@ -27,6 +27,8 @@ esp_err_t nvs_set_u32(nvs_handle_t handle, const char *key, uint32_t value);
 esp_err_t nvs_commit(nvs_handle_t handle);
 void nvs_close(nvs_handle_t handle);
 
+void nvs_mock_reset(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/esp32_mcu/tests_host/mocks/include/wifi_manager.h
+++ b/esp32_mcu/tests_host/mocks/include/wifi_manager.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stdint.h>
+
+#define WPA2_MINIMUM_PASSWORD_LENGTH 8
+#define MAX_SSID_SIZE 32
+#define MAX_PASSWORD_SIZE 64
+#define DEFAULT_AP_SSID "TapGate AP"

--- a/esp32_mcu/tests_host/mocks/nvs_mock.c
+++ b/esp32_mcu/tests_host/mocks/nvs_mock.c
@@ -1,0 +1,253 @@
+#include "nvs.h"
+#include "nvs_flash.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <string.h>
+
+#define MAX_CONTEXTS 8
+#define MAX_ENTRIES 32
+#define MAX_KEY_LENGTH 32
+#define MAX_NAMESPACE_LENGTH 32
+#define MAX_PARTITION_LENGTH 32
+#define MAX_STRING_VALUE 128
+
+typedef struct
+{
+    bool used;
+    char partition[MAX_PARTITION_LENGTH];
+    char ns[MAX_NAMESPACE_LENGTH];
+} mock_context_t;
+
+typedef struct
+{
+    bool used;
+    char partition[MAX_PARTITION_LENGTH];
+    char ns[MAX_NAMESPACE_LENGTH];
+    char key[MAX_KEY_LENGTH];
+    bool is_string;
+    char string_value[MAX_STRING_VALUE];
+    uint32_t u32_value;
+} mock_entry_t;
+
+static mock_context_t s_contexts[MAX_CONTEXTS];
+static mock_entry_t s_entries[MAX_ENTRIES];
+
+static size_t mock_strnlen(const char *str, size_t max_len)
+{
+    if (!str)
+        return 0;
+    size_t len = 0;
+    while (len < max_len && str[len])
+        ++len;
+    return len;
+}
+
+static mock_context_t *find_context_by_handle(nvs_handle_t handle)
+{
+    if (handle == 0 || handle > MAX_CONTEXTS)
+        return NULL;
+    mock_context_t *ctx = &s_contexts[handle - 1];
+    return ctx->used ? ctx : NULL;
+}
+
+static mock_entry_t *find_entry(const mock_context_t *ctx, const char *key, bool is_string)
+{
+    if (!ctx || !key)
+        return NULL;
+    for (size_t i = 0; i < MAX_ENTRIES; ++i)
+    {
+        mock_entry_t *entry = &s_entries[i];
+        if (!entry->used)
+            continue;
+        if (entry->is_string != is_string)
+            continue;
+        if (strncmp(entry->partition, ctx->partition, sizeof(entry->partition)) != 0)
+            continue;
+        if (strncmp(entry->ns, ctx->ns, sizeof(entry->ns)) != 0)
+            continue;
+        if (strncmp(entry->key, key, sizeof(entry->key)) != 0)
+            continue;
+        return entry;
+    }
+    return NULL;
+}
+
+static mock_entry_t *allocate_entry(const mock_context_t *ctx, const char *key, bool is_string)
+{
+    if (!ctx || !key)
+        return NULL;
+    for (size_t i = 0; i < MAX_ENTRIES; ++i)
+    {
+        mock_entry_t *entry = &s_entries[i];
+        if (entry->used)
+            continue;
+        entry->used = true;
+        entry->is_string = is_string;
+        strncpy(entry->partition, ctx->partition, sizeof(entry->partition) - 1);
+        entry->partition[sizeof(entry->partition) - 1] = '\0';
+        strncpy(entry->ns, ctx->ns, sizeof(entry->ns) - 1);
+        entry->ns[sizeof(entry->ns) - 1] = '\0';
+        strncpy(entry->key, key, sizeof(entry->key) - 1);
+        entry->key[sizeof(entry->key) - 1] = '\0';
+        entry->string_value[0] = '\0';
+        entry->u32_value = 0;
+        return entry;
+    }
+    return NULL;
+}
+
+static void clear_partition_entries(const char *partition)
+{
+    if (!partition)
+        return;
+    for (size_t i = 0; i < MAX_ENTRIES; ++i)
+    {
+        if (!s_entries[i].used)
+            continue;
+        if (strncmp(s_entries[i].partition, partition, sizeof(s_entries[i].partition)) == 0)
+        {
+            s_entries[i].used = false;
+        }
+    }
+}
+
+void nvs_mock_reset(void)
+{
+    memset(s_contexts, 0, sizeof(s_contexts));
+    memset(s_entries, 0, sizeof(s_entries));
+}
+
+esp_err_t nvs_flash_init_partition(const char *partition_name)
+{
+    (void)partition_name;
+    return ESP_OK;
+}
+
+esp_err_t nvs_flash_erase_partition(const char *partition_name)
+{
+    clear_partition_entries(partition_name);
+    return ESP_OK;
+}
+
+esp_err_t nvs_open_from_partition(const char *partition_name,
+                                  const char *namespace_name,
+                                  nvs_open_mode open_mode,
+                                  nvs_handle_t *out_handle)
+{
+    if (!partition_name || !namespace_name || !out_handle)
+        return ESP_ERR_INVALID_ARG;
+
+    for (size_t i = 0; i < MAX_CONTEXTS; ++i)
+    {
+        mock_context_t *ctx = &s_contexts[i];
+        if (!ctx->used)
+            continue;
+        if (strncmp(ctx->partition, partition_name, sizeof(ctx->partition)) != 0)
+            continue;
+        if (strncmp(ctx->ns, namespace_name, sizeof(ctx->ns)) != 0)
+            continue;
+        *out_handle = (nvs_handle_t)(i + 1);
+        return ESP_OK;
+    }
+
+    if (open_mode == NVS_READONLY)
+        return ESP_ERR_NVS_NOT_FOUND;
+
+    for (size_t i = 0; i < MAX_CONTEXTS; ++i)
+    {
+        mock_context_t *ctx = &s_contexts[i];
+        if (ctx->used)
+            continue;
+        ctx->used = true;
+        strncpy(ctx->partition, partition_name, sizeof(ctx->partition) - 1);
+        ctx->partition[sizeof(ctx->partition) - 1] = '\0';
+        strncpy(ctx->ns, namespace_name, sizeof(ctx->ns) - 1);
+        ctx->ns[sizeof(ctx->ns) - 1] = '\0';
+        *out_handle = (nvs_handle_t)(i + 1);
+        return ESP_OK;
+    }
+
+    return ESP_ERR_NO_MEM;
+}
+
+esp_err_t nvs_get_str(nvs_handle_t handle, const char *key, char *out_value, size_t *length)
+{
+    mock_context_t *ctx = find_context_by_handle(handle);
+    if (!ctx || !length)
+        return ESP_ERR_INVALID_ARG;
+
+    mock_entry_t *entry = find_entry(ctx, key, true);
+    if (!entry)
+        return ESP_ERR_NVS_NOT_FOUND;
+
+    size_t required = mock_strnlen(entry->string_value, sizeof(entry->string_value)) + 1;
+    if (*length < required)
+    {
+        *length = required;
+        return ESP_ERR_NO_MEM;
+    }
+
+    if (out_value)
+        memcpy(out_value, entry->string_value, required);
+    *length = required;
+    return ESP_OK;
+}
+
+esp_err_t nvs_set_str(nvs_handle_t handle, const char *key, const char *value)
+{
+    mock_context_t *ctx = find_context_by_handle(handle);
+    if (!ctx || !key || !value)
+        return ESP_ERR_INVALID_ARG;
+
+    mock_entry_t *entry = find_entry(ctx, key, true);
+    if (!entry)
+        entry = allocate_entry(ctx, key, true);
+    if (!entry)
+        return ESP_ERR_NO_MEM;
+
+    strncpy(entry->string_value, value, sizeof(entry->string_value) - 1);
+    entry->string_value[sizeof(entry->string_value) - 1] = '\0';
+    return ESP_OK;
+}
+
+esp_err_t nvs_get_u32(nvs_handle_t handle, const char *key, uint32_t *out_value)
+{
+    mock_context_t *ctx = find_context_by_handle(handle);
+    if (!ctx || !key || !out_value)
+        return ESP_ERR_INVALID_ARG;
+
+    mock_entry_t *entry = find_entry(ctx, key, false);
+    if (!entry)
+        return ESP_ERR_NVS_NOT_FOUND;
+
+    *out_value = entry->u32_value;
+    return ESP_OK;
+}
+
+esp_err_t nvs_set_u32(nvs_handle_t handle, const char *key, uint32_t value)
+{
+    mock_context_t *ctx = find_context_by_handle(handle);
+    if (!ctx || !key)
+        return ESP_ERR_INVALID_ARG;
+
+    mock_entry_t *entry = find_entry(ctx, key, false);
+    if (!entry)
+        entry = allocate_entry(ctx, key, false);
+    if (!entry)
+        return ESP_ERR_NO_MEM;
+
+    entry->u32_value = value;
+    return ESP_OK;
+}
+
+esp_err_t nvs_commit(nvs_handle_t handle)
+{
+    (void)handle;
+    return ESP_OK;
+}
+
+void nvs_close(nvs_handle_t handle)
+{
+    (void)handle;
+}

--- a/esp32_mcu/tests_host/test_admin_portal_device.c
+++ b/esp32_mcu/tests_host/test_admin_portal_device.c
@@ -1,0 +1,95 @@
+#include "unity.h"
+
+#include "admin_portal_device.h"
+#include "admin_portal_state.h"
+#include "nvm/nvm.h"
+#include "nvs.h"
+
+static admin_portal_state_t state;
+
+void setUp(void)
+{
+    nvs_mock_reset();
+    admin_portal_state_init(&state, ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN * 60U * 1000U,
+                            WPA2_MINIMUM_PASSWORD_LENGTH);
+}
+
+void tearDown(void)
+{
+}
+
+void test_load_uses_defaults_when_storage_empty(void)
+{
+    esp_err_t err = admin_portal_device_load(&state);
+    TEST_ASSERT_EQUAL_INT(ESP_OK, err);
+    TEST_ASSERT_EQUAL_STRING(DEFAULT_AP_SSID, admin_portal_state_get_ssid(&state));
+    TEST_ASSERT_FALSE(admin_portal_state_has_password(&state));
+    TEST_ASSERT_EQUAL_UINT32(ADMIN_PORTAL_DEFAULT_IDLE_TIMEOUT_MIN * 60U * 1000U,
+                             state.inactivity_timeout_ms);
+}
+
+void test_load_uses_persisted_values(void)
+{
+    TEST_ASSERT_EQUAL_INT(ESP_OK,
+                          nvm_wifi_write_string(ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_SSID, "My Portal"));
+    TEST_ASSERT_EQUAL_INT(ESP_OK,
+                          nvm_wifi_write_string(ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_PSW, "superpass"));
+    TEST_ASSERT_EQUAL_INT(ESP_OK,
+                          nvm_wifi_write_u32(ADMIN_PORTAL_NVM_NAMESPACE_KEY_IDLE_TIMEOUT, 5));
+
+    esp_err_t err = admin_portal_device_load(&state);
+    TEST_ASSERT_EQUAL_INT(ESP_OK, err);
+    TEST_ASSERT_EQUAL_STRING("My Portal", admin_portal_state_get_ssid(&state));
+    TEST_ASSERT_TRUE(admin_portal_state_has_password(&state));
+    TEST_ASSERT_EQUAL_UINT32(5U * 60U * 1000U, state.inactivity_timeout_ms);
+}
+
+void test_save_password_updates_state_and_storage(void)
+{
+    const char *password = "newpassword";
+    esp_err_t err = admin_portal_device_save_password(&state, password);
+    TEST_ASSERT_EQUAL_INT(ESP_OK, err);
+    TEST_ASSERT_TRUE(admin_portal_state_verify_password(&state, password));
+
+    char buffer[MAX_PASSWORD_SIZE] = {0};
+    TEST_ASSERT_EQUAL_INT(ESP_OK,
+                          nvm_wifi_read_string(ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_PSW, buffer, sizeof(buffer)));
+    TEST_ASSERT_EQUAL_STRING(password, buffer);
+}
+
+void test_save_ssid_updates_state_and_storage(void)
+{
+    const char *ssid = "Updated Portal";
+    esp_err_t err = admin_portal_device_save_ssid(&state, ssid);
+    TEST_ASSERT_EQUAL_INT(ESP_OK, err);
+    TEST_ASSERT_EQUAL_STRING(ssid, admin_portal_state_get_ssid(&state));
+
+    char buffer[MAX_SSID_SIZE] = {0};
+    TEST_ASSERT_EQUAL_INT(ESP_OK,
+                          nvm_wifi_read_string(ADMIN_PORTAL_NVM_NAMESPACE_KEY_AP_SSID, buffer, sizeof(buffer)));
+    TEST_ASSERT_EQUAL_STRING(ssid, buffer);
+}
+
+void test_save_timeout_persists_minutes_and_updates_state(void)
+{
+    esp_err_t err = admin_portal_device_save_timeout(&state, 20);
+    TEST_ASSERT_EQUAL_INT(ESP_OK, err);
+    TEST_ASSERT_EQUAL_UINT32(20U * 60U * 1000U, state.inactivity_timeout_ms);
+
+    uint32_t stored = 0;
+    TEST_ASSERT_EQUAL_INT(ESP_OK,
+                          nvm_wifi_read_u32(ADMIN_PORTAL_NVM_NAMESPACE_KEY_IDLE_TIMEOUT, &stored));
+    TEST_ASSERT_EQUAL_UINT32(20U, stored);
+}
+
+int main(int argc, char **argv)
+{
+    UnityConfigureFromArgs(argc, (const char **)argv);
+    UNITY_BEGIN();
+    RUN_TEST(test_load_uses_defaults_when_storage_empty);
+    RUN_TEST(test_load_uses_persisted_values);
+    RUN_TEST(test_save_password_updates_state_and_storage);
+    RUN_TEST(test_save_ssid_updates_state_and_storage);
+    RUN_TEST(test_save_timeout_persists_minutes_and_updates_state);
+    return UNITY_END();
+}


### PR DESCRIPTION
## Summary
- add persistent admin portal state management with session authorization, timeout handling, and NVM-backed credentials
- implement HTTP routing layer that serves assets, enforces single-client access, and exposes REST endpoints for enrollment, login, and device updates
- integrate service into the HTTP server startup and provide unit-test scaffolding covering page resolution and session flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d70441b010832ea8611b9a5384c800