### PR TITLE
Fix portal-name field loading issue

### DIFF
--- a/esp32_mcu/components/admin_portal/assets/app.js
+++ b/esp32_mcu/components/admin_portal/assets/app.js
@@ -280,10 +280,41 @@
     });
   }
 
+  function applyInitialData() {
+    const initialData = window.TAPGATE_INITIAL_DATA;
+    if (!initialData || !initialData.ap_ssid) {
+      console.log("No initial data from server");
+      return;
+    }
+
+    console.log("Applying initial data from server:", initialData);
+
+    const portalName = initialData.ap_ssid || "";
+
+    document.querySelectorAll("[data-bind='portal-name']").forEach((el) => {
+      if (el.tagName === "INPUT") {
+        if (!el.value.trim()) {
+          el.value = portalName;
+          console.log(`Set portal input value to: "${portalName}"`);
+        }
+        el.defaultValue = portalName;
+        el.classList.remove("error");
+      } else {
+        el.textContent = portalName;
+      }
+    });
+
+    document.querySelectorAll("[data-bind='ssid']").forEach((el) => {
+      if (el.tagName === "INPUT") el.value = initialData.ap_ssid;
+      else el.textContent = initialData.ap_ssid;
+    });
+  }
+
   function initializePage() {
     console.log("Initializing simple form handling (no AJAX)");
     ensureRequiredElements();
     attachFormHandlers();
+    applyInitialData();
   }
 
   // Initialize when DOM is ready

--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -438,6 +438,12 @@ static esp_err_t send_asset(httpd_req_t *req, const admin_portal_asset_t *asset)
 
 static esp_err_t send_initial_data_script(httpd_req_t *req)
 {
+    // Refresh SSID from wifi_manager to ensure it's current
+    char current_ssid[sizeof(g_state.ap_ssid)];
+    if (wifi_get_ap_ssid(current_ssid, sizeof(current_ssid))) {
+        admin_portal_state_set_ssid(&g_state, current_ssid);
+    }
+    
     const char *ssid = admin_portal_state_get_ssid(&g_state);
     bool has_password = admin_portal_state_has_password(&g_state);
     bool authorized = admin_portal_state_session_authorized(&g_state);


### PR DESCRIPTION
## Problem
During loading, the value for the portal-name field was lost. The logs showed that the value was successfully obtained from wifi_manager via the wifi_get_ap_ssid API, but after the Enroll page was loaded, this value was missing from the UI.

## Root Cause
The current `app.js` file was missing the data binding functionality that was present in `app_old.js`. Specifically, the `applyInitialData()` function that populates portal-name fields with the SSID value retrieved from the server was not included.

## Solution
1. **Restored data binding functionality**: Added `applyInitialData()` function to `app.js` that reads the SSID from `window.TAPGATE_INITIAL_DATA` and populates all elements with `data-bind='portal-name'` attribute.

2. **Enhanced SSID freshness**: Modified `send_initial_data_script()` function in `http_service.c` to refresh the SSID from wifi_manager before serving the initial data, ensuring the most current value is always provided.

## Changes
- `esp32_mcu/components/admin_portal/assets/app.js`: Added `applyInitialData()` function and integrated it into the page initialization
- `esp32_mcu/components/admin_portal/http_service.c`: Added SSID refresh in `send_initial_data_script()` function

## Testing
The fix ensures that:
- Portal-name input fields are properly populated with the current SSID on page load
- The value is retrieved fresh from wifi_manager via the existing wifi_get_ap_ssid API
- Both readonly and editable portal-name fields display the correct value

Fixes the issue where portal-name field value was lost during loading despite being successfully retrieved by wifi_get_ap_ssid.