### PR TITLE
feat: implement password confirmation validation on Enroll page

### DIFF
--- a/esp32_mcu/components/admin_portal/assets/app.js
+++ b/esp32_mcu/components/admin_portal/assets/app.js
@@ -65,6 +65,17 @@
         }
         return false;
       }
+
+      const confirmPasswordInput = form.elements["confirm_password"];
+      if (passwordInput && confirmPasswordInput && passwordInput.value !== confirmPasswordInput.value) {
+        setFieldError(form, "confirm_password", true);
+        setMessage(form, "Passwords do not match.");
+        focusField(form, "password");
+        if (typeof passwordInput.select === "function") {
+          passwordInput.select();
+        }
+        return false;
+      }
     }
 
     if (actionKey === "login") {

--- a/esp32_mcu/components/admin_portal/assets/page_enroll.html
+++ b/esp32_mcu/components/admin_portal/assets/page_enroll.html
@@ -30,7 +30,7 @@
         <input type="password" name="confirm_password" minlength="8" required placeholder="Must match above">
       </label>
       <div class="message" data-message></div>
-      <button type="submit">Ok</button>
+      <button type="submit">Submit</button>
     </form>
   </main>
 </body>


### PR DESCRIPTION
## Changes

This PR implements password confirmation functionality for the Enroll page as requested:

### What's Changed
- ✅ **Password confirmation validation**: Added validation logic in  to check that password and confirm_password fields match
- ✅ **Error handling**: Display appropriate error message when passwords don't match
- ✅ **Focus management**: Move cursor focus to the password field when validation fails
- ✅ **Form submission prevention**: Prevent navigation/form submission when passwords don't match
- ✅ **Button text update**: Changed button text from 'Ok' to 'Submit' on Enroll page

### Technical Details
- Enhanced the  function in  for the 'enroll' action
- Added password match validation after existing password length validation
- Displays "Passwords do not match." error message
- Focuses and selects the password field when mismatch occurs
- Updated button text in 

### Files Modified
-  - Added password confirmation validation
-  - Changed button text

### Testing
The implementation follows existing patterns in the codebase:
- Uses the same error handling mechanism as other form validations
- Follows the same focus and selection pattern for user experience
- Maintains consistency with existing validation messages

### Resolves
Password confirmation functionality requirements as specified.