### PR TITLE
feat: implement password confirmation for change password form

### DIFF
--- a/esp32_mcu/components/admin_portal/assets/app.js
+++ b/esp32_mcu/components/admin_portal/assets/app.js
@@ -91,6 +91,7 @@
     if (actionKey === "changePassword") {
       const currentInput = form.elements["current"];
       const nextInput = form.elements["next"];
+      const confirmPasswordInput = form.elements["confirm_password"];
       
       if (currentInput && !currentInput.value) {
         setFieldError(form, "current", true);
@@ -105,6 +106,16 @@
         focusField(form, "next");
         if (typeof nextInput.select === "function") {
           nextInput.select();
+        }
+        return false;
+      }
+      
+      if (nextInput && confirmPasswordInput && nextInput.value !== confirmPasswordInput.value) {
+        setFieldError(form, "confirm_password", true);
+        setMessage(form, "Passwords do not match.");
+        focusField(form, "confirm_password");
+        if (typeof confirmPasswordInput.select === "function") {
+          confirmPasswordInput.select();
         }
         return false;
       }

--- a/esp32_mcu/components/admin_portal/assets/page_change_psw.html
+++ b/esp32_mcu/components/admin_portal/assets/page_change_psw.html
@@ -25,6 +25,10 @@
         New password
         <input type="password" name="next" minlength="8" autocomplete="new-password" required>
       </label>
+      <label>
+        Confirm Password
+        <input type="password" name="confirm_password" minlength="8" required placeholder="Must match above">
+      </label>
       <div class="message" data-message></div>
       <div class="actions">
         <button type="submit">Submit</button>


### PR DESCRIPTION
- Add confirm password field to change password page
- Implement client-side validation to ensure passwords match
- Display error message and focus on confirm_password field if passwords don't match
- Prevent form submission when passwords don't match
- Allow normal form submission when passwords match

Fixes password confirmation functionality as requested.