### PR TITLE
Fix: Admin Session Management - Prevent Ghost Sessions After Logout

### DIFF
--- a/esp32_mcu/components/admin_portal/http_service.c
+++ b/esp32_mcu/components/admin_portal/http_service.c
@@ -1010,7 +1010,12 @@ static esp_err_t handle_page_request(httpd_req_t *req, const admin_portal_page_d
     if (target != desc->page)
         return send_redirect(req, target);
 
-    if (status == ADMIN_PORTAL_SESSION_NONE && desc->page != ADMIN_PORTAL_PAGE_BUSY)
+    // Only auto-create sessions for pages that need them
+    // AUTH page should not auto-create sessions - sessions should only be created upon successful authentication
+    // BUSY page should never create sessions
+    if (status == ADMIN_PORTAL_SESSION_NONE && 
+        desc->page != ADMIN_PORTAL_PAGE_BUSY && 
+        desc->page != ADMIN_PORTAL_PAGE_AUTH)
         create_session(req, token, sizeof(token));
 
     return send_page_content(req, desc);


### PR DESCRIPTION
## Problem

After logging out, clients were incorrectly redirected to the busy page instead of the auth page. This happened because of ghost sessions being created unintentionally.

**Root Cause Analysis:**
1. Client A logs off → session correctly cleared
2. Client A accesses `/auth/` page → AUTH page auto-creates new session 
3. Same client makes request with different device fingerprint → sees existing session as 'BUSY'

**From IoT logs:**
```
I (00:01:46.030) AdminPortal: User logged off - session cleared
I (00:01:46.058) AdminPortal: Session evaluation: IP=10.10.0.100, token=none, fingerprint=0eb545c0, status=NONE  ✓
I (00:01:46.078) AdminPortal: New session created: IP=10.10.0.100, token=99cd1ef5..., fingerprint=0eb545c0  ← Problem!
I (00:01:46.178) AdminPortal: Session evaluation: IP=10.10.0.100, token=none, fingerprint=481cf99a, status=BUSY  ← Wrong!
```

## Solution

**Prevent AUTH page from auto-creating sessions.**

Sessions should only be created when:
- ✅ Accessing ENROLL page (needed for enrollment workflow)
- ✅ Making authentication API calls (`/api/login`, `/api/enroll`)
- ❌ ~~Visiting AUTH page~~ (should just display login form)

## Code Changes

Modified `handle_page_request()` in `http_service.c`:

```c
// Only auto-create sessions for pages that need them
// AUTH page should not auto-create sessions - sessions should only be created upon successful authentication
// BUSY page should never create sessions
if (status == ADMIN_PORTAL_SESSION_NONE && 
    desc->page != ADMIN_PORTAL_PAGE_BUSY && 
    desc->page != ADMIN_PORTAL_PAGE_AUTH)
    create_session(req, token, sizeof(token));
```

## Expected Behavior After Fix

### Scenario 1: Normal Logout/Login Flow
1. Client A logs in and uses system
2. Client B accesses → gets busy page ✅
3. Client A logs off → session cleared → redirected to auth page ✅
4. Client A sees auth page (no ghost session created) ✅  
5. Client B can now access system ✅

### Scenario 2: Re-authentication
1. Client A logs off → redirected to auth page
2. Client A enters password → `/api/login` creates new session ✅
3. Client A redirected to main page ✅

### Scenario 3: Session Timeout
1. Session times out naturally
2. Next access → redirected to auth page
3. No ghost sessions created ✅

## Security Considerations

✅ **Proper session lifecycle:** Sessions created only when needed  
✅ **No race conditions:** Logout properly clears state before redirect  
✅ **Ghost session prevention:** AUTH page access doesn't create sessions  
✅ **Multiple client support:** Other clients can access after logout  

## Testing Checklist

- [ ] Client A logs in, Client B sees busy page
- [ ] Client A logs off, gets redirected to auth page (not busy)
- [ ] Client B can access system after A logs off
- [ ] Client A can re-authenticate successfully  
- [ ] Session timeout works correctly
- [ ] Enrollment flow still works properly

Resolves admin session management issues described in project logs.