### PR TITLE
Add WiFi scan JSON generation function

### DIFF
--- a/esp32_mcu/components/admin_portal/admin_portal_device.c
+++ b/esp32_mcu/components/admin_portal/admin_portal_device.c
@@ -3,6 +3,9 @@
 #include "nvm/nvm.h"
 #include "logs.h"
 #include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include "esp_wifi.h"
 
 // NVM Partition to store admin portal data
 #define NVM_ADMIN_PORTAL_PARTITION   NVM_PARTITION_DEFAULT
@@ -118,4 +121,113 @@ void session_set_idle_timeout(uint32_t timeout_value)
 void trigger_scan_wifi()
 {
     wifi_manager_scan_async();
+}
+
+char* create_json_from_ap_records()
+{
+    uint16_t ap_count = 0;
+    wifi_ap_record_t ap_records[MAX_AP_NUM];
+    
+    // Get scan results from ESP-IDF
+    esp_err_t err = esp_wifi_scan_get_ap_records(&ap_count, ap_records);
+    if (err != ESP_OK) {
+        LOGE(TAG, "Failed to get AP records: %s", esp_err_to_name(err));
+        return NULL;
+    }
+    
+    if (ap_count == 0) {
+        // Return empty JSON array
+        char* result = malloc(3);
+        if (result) {
+            strcpy(result, "[]");
+        }
+        return result;
+    }
+    
+    // Calculate buffer size needed for JSON
+    // Each entry needs approximately: {"ssid":"<ssid>","chan":<chan>,"rssi":<rssi>,"auth":<auth>},
+    // Maximum SSID length is 32 chars, so roughly 80 bytes per entry plus array brackets
+    size_t buffer_size = ap_count * 120 + 10;
+    char* json_buffer = malloc(buffer_size);
+    if (!json_buffer) {
+        LOGE(TAG, "Failed to allocate memory for JSON buffer");
+        return NULL;
+    }
+    
+    // Track seen SSIDs to filter duplicates
+    char seen_ssids[MAX_AP_NUM][33]; // 32 chars + null terminator
+    uint16_t seen_count = 0;
+    
+    // Start building JSON array
+    strcpy(json_buffer, "[");
+    bool first_entry = true;
+    
+    for (uint16_t i = 0; i < ap_count && i < MAX_AP_NUM; i++) {
+        // Filter out empty SSIDs
+        if (ap_records[i].ssid[0] == '\0') {
+            continue;
+        }
+        
+        // Check for duplicate SSIDs
+        bool is_duplicate = false;
+        for (uint16_t j = 0; j < seen_count; j++) {
+            if (strcmp((char*)ap_records[i].ssid, seen_ssids[j]) == 0) {
+                is_duplicate = true;
+                break;
+            }
+        }
+        
+        if (is_duplicate) {
+            continue;
+        }
+        
+        // Add SSID to seen list
+        if (seen_count < MAX_AP_NUM) {
+            strncpy(seen_ssids[seen_count], (char*)ap_records[i].ssid, 32);
+            seen_ssids[seen_count][32] = '\0';
+            seen_count++;
+        }
+        
+        // Add comma separator for subsequent entries
+        if (!first_entry) {
+            strcat(json_buffer, ",");
+        }
+        first_entry = false;
+        
+        // Escape SSID for JSON (basic escaping for quotes and backslashes)
+        char escaped_ssid[66]; // 32 * 2 + 2 for worst case
+        size_t escaped_len = 0;
+        const char* ssid_ptr = (char*)ap_records[i].ssid;
+        
+        while (*ssid_ptr && escaped_len < sizeof(escaped_ssid) - 3) {
+            if (*ssid_ptr == '"') {
+                escaped_ssid[escaped_len++] = '\\';
+                escaped_ssid[escaped_len++] = '"';
+            } else if (*ssid_ptr == '\\') {
+                escaped_ssid[escaped_len++] = '\\';
+                escaped_ssid[escaped_len++] = '\\';
+            } else {
+                escaped_ssid[escaped_len++] = *ssid_ptr;
+            }
+            ssid_ptr++;
+        }
+        escaped_ssid[escaped_len] = '\0';
+        
+        // Build JSON entry
+        char entry[150];
+        snprintf(entry, sizeof(entry), 
+                "{\"ssid\":\"%s\",\"chan\":%d,\"rssi\":%d,\"auth\":%d}",
+                escaped_ssid,
+                ap_records[i].primary,
+                ap_records[i].rssi,
+                ap_records[i].authmode);
+        
+        strcat(json_buffer, entry);
+    }
+    
+    // Close JSON array
+    strcat(json_buffer, "]");
+    
+    LOGI(TAG, "Generated JSON for %d WiFi access points", seen_count);
+    return json_buffer;
 }

--- a/esp32_mcu/components/admin_portal/admin_portal_device.h
+++ b/esp32_mcu/components/admin_portal/admin_portal_device.h
@@ -17,3 +17,6 @@ uint32_t session_get_idle_timeout();
 void session_set_idle_timeout(uint32_t timeout_value);
 
 void trigger_scan_wifi();
+
+// Create JSON string from WiFi scan results
+char* create_json_from_ap_records();


### PR DESCRIPTION
## Summary

Implements the  function that creates a JSON array from WiFi access point scan results.

## Features

- **Filters empty SSIDs**: Excludes access points with no SSID
- **Removes duplicates**: Filters out duplicate SSIDs to avoid redundant entries
- **JSON format**: Returns properly formatted JSON with fields: , , , 
- **Memory safe**: Dynamic memory allocation with proper error handling
- **JSON escaping**: Properly escapes special characters in SSID names

## Example Output

```json
[
  {"ssid":"dlink-D9D8","chan":11,"rssi":-82,"auth":4},
  {"ssid":"SINGTEL-5171","chan":9,"rssi":-88,"auth":4}
]
```

## Technical Details

- Added function declaration to 
- Implemented in  with ESP-IDF WiFi API integration
- Uses  to retrieve scan results
- Includes proper error handling and logging
- Returns C string format as requested

## Testing

The function can be called after a WiFi scan is completed to generate the JSON representation of discovered access points.