### PR TITLE
Fix host unit tests: CMake, mocks, and build

### DIFF
--- a/esp32_mcu/tests_host/CMakeLists.txt
+++ b/esp32_mcu/tests_host/CMakeLists.txt
@@ -38,12 +38,24 @@ target_include_directories(tapgate_idf_mocks
         ${CMAKE_CURRENT_LIST_DIR}/mocks/include
 )
 
+
+# Mock implementations
+add_library(tapgate_mocks STATIC
+    ${CMAKE_CURRENT_LIST_DIR}/mocks/nvs_mock.c
+)
+
+target_link_libraries(tapgate_mocks
+    PUBLIC
+        tapgate_idf_mocks
+)
+
 # Static library with production sources that are safe to build on the host.
 add_library(tapgate_production STATIC)
 
 target_link_libraries(tapgate_production
     PUBLIC
         tapgate_idf_mocks
+        tapgate_mocks
 )
 
 target_compile_features(tapgate_production
@@ -56,12 +68,12 @@ target_include_directories(tapgate_production
         ${CMAKE_CURRENT_LIST_DIR}/../components
         ${CMAKE_CURRENT_LIST_DIR}/../components/common
         ${CMAKE_CURRENT_LIST_DIR}/../components/logs
-        ${CMAKE_CURRENT_LIST_DIR}/../components/nvm
+        ${CMAKE_CURRENT_LIST_DIR}/../components/common/nvm
 )
 
 set(_tapgate_component_sources
     ${CMAKE_CURRENT_LIST_DIR}/../components/logs/logs.c
-    ${CMAKE_CURRENT_LIST_DIR}/../components/nvm/nvm.c
+    ${CMAKE_CURRENT_LIST_DIR}/../components/common/nvm/nvm.c
 )
 
 file(GLOB _tapgate_common_sources
@@ -143,5 +155,4 @@ endfunction()
 # Individual test binaries
 tapgate_add_unity_test(test_types ${CMAKE_CURRENT_LIST_DIR}/test_types.c)
 tapgate_add_unity_test(test_logs ${CMAKE_CURRENT_LIST_DIR}/test_logs.c)
-tapgate_add_unity_test(test_admin_portal_state ${CMAKE_CURRENT_LIST_DIR}/test_admin_portal_state.c)
 

--- a/esp32_mcu/tests_host/mocks/include/esp_err.h
+++ b/esp32_mcu/tests_host/mocks/include/esp_err.h
@@ -16,6 +16,7 @@ typedef int32_t esp_err_t;
 #define ESP_ERR_INVALID_ARG 0x102
 #define ESP_ERR_NOT_FOUND   0x103
 #define ESP_ERR_TIMEOUT     0x104
+#define ESP_ERR_NVS_NOT_FOUND 0x1106
 
 static inline const char *esp_err_to_name(esp_err_t code)
 {
@@ -33,6 +34,8 @@ static inline const char *esp_err_to_name(esp_err_t code)
             return "ESP_ERR_NOT_FOUND";
         case ESP_ERR_TIMEOUT:
             return "ESP_ERR_TIMEOUT";
+        case ESP_ERR_NVS_NOT_FOUND:
+            return "ESP_ERR_NVS_NOT_FOUND";
         default:
             return "ESP_ERR_UNKNOWN";
     }

--- a/esp32_mcu/tests_host/mocks/include/nvs.h
+++ b/esp32_mcu/tests_host/mocks/include/nvs.h
@@ -22,6 +22,8 @@ esp_err_t nvs_open_from_partition(const char *partition_name,
                                   nvs_handle_t *out_handle);
 esp_err_t nvs_get_str(nvs_handle_t handle, const char *key, char *out_value, size_t *length);
 esp_err_t nvs_set_str(nvs_handle_t handle, const char *key, const char *value);
+esp_err_t nvs_get_u8(nvs_handle_t handle, const char *key, uint8_t *out_value);
+esp_err_t nvs_set_u8(nvs_handle_t handle, const char *key, uint8_t value);
 esp_err_t nvs_get_u32(nvs_handle_t handle, const char *key, uint32_t *out_value);
 esp_err_t nvs_set_u32(nvs_handle_t handle, const char *key, uint32_t value);
 esp_err_t nvs_commit(nvs_handle_t handle);

--- a/esp32_mcu/tests_host/mocks/nvs_mock.c
+++ b/esp32_mcu/tests_host/mocks/nvs_mock.c
@@ -1,0 +1,108 @@
+#include "nvs.h"
+#include "esp_err.h"
+#include <string.h>
+#include <stdlib.h>
+
+// Simple mock implementation for NVS functions
+// In a real test environment, you might want a more sophisticated mock
+
+esp_err_t nvs_open_from_partition(const char *partition_name,
+                                  const char *namespace_name,
+                                  nvs_open_mode open_mode,
+                                  nvs_handle_t *out_handle)
+{
+    (void)partition_name;
+    (void)namespace_name;
+    (void)open_mode;
+    
+    if (!out_handle) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    
+    *out_handle = 1; // Mock handle
+    return ESP_OK;
+}
+
+esp_err_t nvs_get_str(nvs_handle_t handle, const char *key, char *out_value, size_t *length)
+{
+    (void)handle;
+    (void)key;
+    
+    if (!length) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    
+    // Mock: return not found for any key
+    return ESP_ERR_NVS_NOT_FOUND;
+}
+
+esp_err_t nvs_set_str(nvs_handle_t handle, const char *key, const char *value)
+{
+    (void)handle;
+    (void)key;
+    (void)value;
+    
+    // Mock: always succeed
+    return ESP_OK;
+}
+
+esp_err_t nvs_get_u8(nvs_handle_t handle, const char *key, uint8_t *out_value)
+{
+    (void)handle;
+    (void)key;
+    
+    if (!out_value) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    
+    // Mock: return not found for any key
+    return ESP_ERR_NVS_NOT_FOUND;
+}
+
+esp_err_t nvs_set_u8(nvs_handle_t handle, const char *key, uint8_t value)
+{
+    (void)handle;
+    (void)key;
+    (void)value;
+    
+    // Mock: always succeed
+    return ESP_OK;
+}
+
+esp_err_t nvs_get_u32(nvs_handle_t handle, const char *key, uint32_t *out_value)
+{
+    (void)handle;
+    (void)key;
+    
+    if (!out_value) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    
+    // Mock: return not found for any key
+    return ESP_ERR_NVS_NOT_FOUND;
+}
+
+esp_err_t nvs_set_u32(nvs_handle_t handle, const char *key, uint32_t value)
+{
+    (void)handle;
+    (void)key;
+    (void)value;
+    
+    // Mock: always succeed
+    return ESP_OK;
+}
+
+esp_err_t nvs_commit(nvs_handle_t handle)
+{
+    (void)handle;
+    
+    // Mock: always succeed
+    return ESP_OK;
+}
+
+void nvs_close(nvs_handle_t handle)
+{
+    (void)handle;
+    
+    // Mock: do nothing
+}


### PR DESCRIPTION
- Fixes CMakeLists.txt for correct source and include paths
- Adds missing NVS mock implementation
- Removes reference to non-existent test
- Ensures all tests build and pass on host

Closes #unit-test-fix