### PR TITLE
Fix CMake MSVC compiler flag compatibility for unit tests

### DIFF
--- a/esp32_mcu/CMakeLists.txt
+++ b/esp32_mcu/CMakeLists.txt
@@ -1,8 +1,14 @@
 # Unified entry point for both ESP-IDF firmware build and host-side tests.
 cmake_minimum_required(VERSION 3.20)
 
-# Disable specific GCC warnings project-wide (C & C++)
-add_compile_options(-Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable)
+# Disable specific warnings project-wide (C & C++)
+if(MSVC)
+    # MSVC warning flags
+    add_compile_options(/wd4101 /wd4189 /wd4996)  # Disable unused variable warnings and deprecation warnings
+else()
+    # GCC/Clang warning flags
+    add_compile_options(-Wno-unused-function -Wno-unused-variable -Wno-unused-but-set-variable)
+endif()
 
 set(PROJECT_NAME esp32-tapgate)
 set(PROJECT_VER "1.0.0")


### PR DESCRIPTION
## Problem
Unit tests were failing to build on Windows with MSVC due to incompatible compiler flags. The build system was applying GCC-style warning flags globally, causing MSVC to throw errors:

```
cl : command line error D8021: invalid numeric argument '/Wno-unused-function'
```

## Solution
Added conditional compiler flag logic in `esp32_mcu/CMakeLists.txt`:

- **MSVC builds**: Use MSVC-specific warning disable flags (`/wd4101`, `/wd4189`, `/wd4996`)
- **GCC/Clang builds**: Keep original flags (`-Wno-unused-function`, `-Wno-unused-variable`, `-Wno-unused-but-set-variable`)

## Testing
✅ CMake configuration works without errors
✅ Build completes successfully (verified on Linux with GCC)
✅ All unit tests pass (2/2 tests)

## Changes
- Modified `esp32_mcu/CMakeLists.txt` to add conditional compiler flag logic
- No functional changes to the codebase, only build system improvements

This ensures cross-platform compatibility for the unit test build system.